### PR TITLE
Fix warnings when build on Linux

### DIFF
--- a/support/dynamic_loader/dynamic_library.cpp
+++ b/support/dynamic_loader/dynamic_library.cpp
@@ -33,7 +33,7 @@ class InternalDynamicLibrary : public DynamicLibrary {
     lib_ = LoadLibrary(lib_with_extension.c_str());
   }
 
-  ~InternalDynamicLibrary() {
+  ~InternalDynamicLibrary() override {
     if (is_valid()) {
       CloseHandle(lib_);
     }
@@ -65,7 +65,7 @@ class InternalDynamicLibrary : public DynamicLibrary {
     lib_ = dlopen(lib_with_extension.c_str(), RTLD_LAZY);
   }
 
-  ~InternalDynamicLibrary() {
+  ~InternalDynamicLibrary() override {
     if (is_valid()) {
       dlclose(lib_);
     }

--- a/support/dynamic_loader/dynamic_library.h
+++ b/support/dynamic_loader/dynamic_library.h
@@ -26,6 +26,8 @@ namespace dynamic_loader {
 // This wraps a system-specific loaded dynamic library.
 class DynamicLibrary {
  public:
+   virtual ~DynamicLibrary() {};
+
   // This resolves a pointer from the opened dynamic library.
   // It automatically casts it to a function pointer of the passed
   // in pointer type.

--- a/support/log/log.h
+++ b/support/log/log.h
@@ -65,6 +65,8 @@ namespace logging {
 // We will have to assume that the STL is doing the right thing here.
 class Logger {
  public:
+   virtual ~Logger() {}
+
   // Logs a set of values to the error stream of the logger.
   template <typename... Args>
   void LogError(Args... args) {


### PR DESCRIPTION
DynamicLibrary and its child classes should have virtual dtor