### PR TITLE
Fix a bug in VulkanArena.

### DIFF
--- a/support/containers/allocator.h
+++ b/support/containers/allocator.h
@@ -1,6 +1,6 @@
 /* Copyright 2017 Google Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -16,11 +16,39 @@
 #ifndef SUPPORT_CONTAINERS_ALLOCATOR_H_
 #define SUPPORT_CONTAINERS_ALLOCATOR_H_
 
+#include <assert.h>
 #include <atomic>
 #include <cstdlib>
+#include <map>
 #include <utility>
 
 namespace containers {
+struct Allocator {
+  virtual void* malloc(size_t val) = 0;
+  virtual void free(void* val, size_t size) = 0;
+
+  // Constructs one T from this allocator, while passing
+  // down args to the constructor. The memory is allocated
+  // from this allocator.
+  template <typename T, typename... Args>
+  T* construct(Args&&... args) {
+    // We assume that the maximum natural alignment for anything
+    // is 16 bytes. This will handle all SSE types.
+    T* t =
+        reinterpret_cast<T*>(16 + static_cast<char*>(malloc(sizeof(T) + 16)));
+    size_t* s = reinterpret_cast<size_t*>(reinterpret_cast<char*>(t) - 16);
+    *s = sizeof(T) + 16;
+    return ::new ((void*)t) T(std::forward<Args>(args)...);
+  }
+
+  template <typename T>
+  void destroy(T* t) {
+    size_t* s = reinterpret_cast<size_t*>(reinterpret_cast<char*>(t) - 16);
+    t->~T();
+    free(s, *s);
+  }
+};
+
 // When a user allocates/frees memory from this allocator,
 // it tracks the total number of allocations made, the total
 // number of bytes current in allocation, and the total number
@@ -30,8 +58,8 @@ namespace containers {
 // These numbers are particularly useful at the end of
 // this allocator's lifetime, where all child objects
 // should have already been destroyed.
-struct Allocator {
-  Allocator() {
+struct LeakCheckAllocator : public Allocator {
+  LeakCheckAllocator() {
     currently_allocated_bytes_.store(0);
     total_allocated_bytes_.store(0);
     total_number_of_allocations_.store(0);
@@ -40,7 +68,7 @@ struct Allocator {
   // Allocates val bytes from this allocator.
   // Tracks one additional usage, and an additional
   // `val` bytes.
-  void* malloc(size_t val) {
+  void* malloc(size_t val) override {
     currently_allocated_bytes_ += val;
     total_allocated_bytes_ += val;
     total_number_of_allocations_ += 1;
@@ -50,24 +78,42 @@ struct Allocator {
 
   // Free val from the allocator.
   // Releases the tracking of `bytes` bytes.
-  void free(void* val, size_t bytes) {
+  void free(void* val, size_t bytes) override {
     currently_allocated_bytes_ -= bytes;
     ::free(val);
   }
 
-  // Constructs one T from this allocator, while passing
-  // down args to the constructor. The memory is allocated
-  // from this allocator.
-  template <typename T, typename... Args>
-  T* construct(Args&&... args) {
-    T* t = static_cast<T*>(malloc(sizeof(T)));
-    return ::new ((void*)t) T(std::forward<Args>(args)...);
-  }
   std::atomic<size_t> currently_allocated_bytes_;
   std::atomic<uint64_t> total_allocated_bytes_;
   std::atomic<uint64_t> total_number_of_allocations_;
 };
 
+#define RELEASE_ASSERT(x)                              \
+  do {                                                 \
+    if (!x) {                                          \
+      *reinterpret_cast<volatile int*>(size_t(0)) = 4; \
+    }                                                  \
+  } while (false)
+
+struct CheckedAllocator : public Allocator {
+  CheckedAllocator(Allocator* _alloc) : m_root_allocator(_alloc) {}
+  void* malloc(size_t val) override {
+    void* ret_val = m_root_allocator->malloc(val);
+    m_allocations[ret_val] = val;
+    return ret_val;
+  }
+
+  void free(void* val, size_t bytes) override {
+    RELEASE_ASSERT(m_allocations[val] == bytes);
+    m_allocations.erase(val);
+    return m_root_allocator->free(val, bytes);
+  }
+
+  std::map<void*, size_t> m_allocations;
+  Allocator* m_root_allocator;
+};
+
+#undef RELEASE_ASSERT
 }  // namespace containers
 
 #endif  // SUPPORT_CONTAINERS_ALLOCATOR_H_

--- a/support/entry/entry.cpp
+++ b/support/entry/entry.cpp
@@ -129,7 +129,7 @@ void android_main(android_app* app) {
     int32_t height = output_frame >= 0 ? DEFAULT_WINDOW_HEIGHT
                                        : ANativeWindow_getHeight(app->window);
 
-    containers::Allocator root_allocator;
+    containers::LeakCheckAllocator root_allocator;
     {
       entry::entry_data data{
           app->window,
@@ -199,7 +199,7 @@ int main(int argc, char** argv) {
   CommandLineArgs args;
   parse_args(&args, argc, argv);
 
-  containers::Allocator root_allocator;
+  containers::LeakCheckAllocator root_allocator;
   xcb_connection_t* connection;
   xcb_window_t window;
   if (args.output_frame == -1) {
@@ -245,12 +245,15 @@ void write_error(HANDLE handle, const char* message) {
                nullptr);
 }
 
+static char file_path[1024 * 1024] = {};
+static char layer_path[1024 * 1024] = {};
 int main(int argc, const char** argv) {
   CommandLineArgs args;
   parse_args(&args, argc, argv);
-  containers::Allocator root_allocator;
-  HINSTANCE instance;
-  HWND window_handle;
+
+  containers::LeakCheckAllocator root_allocator;
+  HINSTANCE instance = 0;
+  HWND window_handle = 0;
   HANDLE out_handle = GetStdHandle(STD_OUTPUT_HANDLE);
   if (out_handle == INVALID_HANDLE_VALUE) {
     AllocConsole();
@@ -258,6 +261,27 @@ int main(int argc, const char** argv) {
     if (out_handle == INVALID_HANDLE_VALUE) {
       return -1;
     }
+  }
+
+  DWORD path_len = GetModuleFileNameA(NULL, file_path, 1024 * 1024 - 1);
+  if (path_len != -1) {
+    file_path[path_len] = '\0';
+    for (DWORD i = path_len - 1; i >= 0; --i) {
+      // Cut off the exe name
+      if (file_path[i] == '/' || file_path[i] == '\\') {
+        file_path[i] = '\0';
+        break;
+      }
+    }
+    DWORD d =
+        GetEnvironmentVariableA("VK_LAYER_PATH", layer_path, 1024 * 1024 - 1);
+    std::string lp = layer_path;
+    if (d > 0 && !lp.empty()) {
+      lp = lp + ":" + file_path;
+    } else {
+      lp = file_path;
+    }
+    SetEnvironmentVariableA("VK_LAYER_PATH", lp.c_str());
   }
 
   if (args.output_frame == -1) {


### PR DESCRIPTION
We were calling allocator_->free() on an AllocationToken, instead
of deleting it properly. This meant that the iterator
was not getting deleted it was just getting zeroed.

In windows, debug, checked iterators are a lot more than just a
POD type, deleting a checked iterator can modify other iterators
to the same object. (They are internally a big linked list
of all iterators to the same object).