### PR TITLE
A few minor fixes for traces.

### DIFF
--- a/gapid_tests/null_destruction_tests/CMakeLists.txt
+++ b/gapid_tests/null_destruction_tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(vkDestroyNullHandles)

--- a/gapid_tests/null_destruction_tests/README.md
+++ b/gapid_tests/null_destruction_tests/README.md
@@ -1,0 +1,5 @@
+# NullDestruction Tests
+
+These tests are specifically for testing that 
+`VkDestroy*(VK_NULL_HANDLE)` work. These are all in one place
+since some drivers fail all of them.

--- a/gapid_tests/null_destruction_tests/vkDestroyNullHandles/CMakeLists.txt
+++ b/gapid_tests/null_destruction_tests/vkDestroyNullHandles/CMakeLists.txt
@@ -13,19 +13,8 @@
 # limitations under the License.
 #
 
-add_custom_target(GAPID_TESTS)
-
-function(add_gapid_test name)
-    add_vulkan_executable(${name} ${ARGN})
-    add_dependencies(GAPID_TESTS ${name})
-endfunction()
-
-add_subdirectory(command_buffer_tests)
-add_subdirectory(extension_tests)
-add_subdirectory(initialization_tests)
-add_subdirectory(null_destruction_tests)
-add_subdirectory(resource_acquisition_tests)
-add_subdirectory(resource_binding_tests)
-add_subdirectory(resource_creation_tests)
-add_subdirectory(synchronization_tests)
-add_subdirectory(traits_query_tests)
+add_gapid_test(vkDestroyNullHandles_test
+  SOURCES main.cpp
+  LIBS
+    vulkan_helpers
+)

--- a/gapid_tests/null_destruction_tests/vkDestroyNullHandles/main.cpp
+++ b/gapid_tests/null_destruction_tests/vkDestroyNullHandles/main.cpp
@@ -1,0 +1,124 @@
+/* Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "support/containers/vector.h"
+#include "support/entry/entry.h"
+#include "support/log/log.h"
+#include "vulkan_helpers/helper_functions.h"
+#include "vulkan_helpers/known_device_infos.h"
+#include "vulkan_wrapper/device_wrapper.h"
+#include "vulkan_wrapper/instance_wrapper.h"
+#include "vulkan_wrapper/library_wrapper.h"
+
+int main_entry(const entry::entry_data* data) {
+  data->log->LogInfo("Application Startup");
+  vulkan::LibraryWrapper wrapper(data->root_allocator, data->log.get());
+  vulkan::VkInstance instance(
+      vulkan::CreateEmptyInstance(data->root_allocator, &wrapper));
+  containers::vector<VkPhysicalDevice> devices(
+      vulkan::GetPhysicalDevices(data->root_allocator, instance),
+      data->root_allocator);
+
+  float priority = 1.f;
+  VkDeviceQueueCreateInfo queue_info{
+      VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,  // sType
+      nullptr,                                     // pNext
+      0,                                           // flags
+      0,                                           // queueFamilyIndex
+      1,                                           // queueCount
+      &priority                                    // pQueuePriorities
+  };
+
+  VkDeviceCreateInfo info{
+      VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,  // sType
+      nullptr,                               // pNext
+      0,                                     // flags
+      0,                                     // queueCreateInfoCount
+      nullptr,                               // pQueueCreateInfo
+      0,                                     // enabledLayerNames
+      nullptr,                               // ppEnabledLayerNames
+      0,                                     // enabledExtensionCount
+      nullptr,                               // ppEnabledextensionNames
+      nullptr                                // pEnalbedFeatures
+  };
+
+  {
+    info.queueCreateInfoCount = 1;
+    info.pQueueCreateInfos = &queue_info;
+    ::VkDevice raw_device;
+    LOG_EXPECT(==, data->log, instance->vkCreateDevice(devices[0], &info,
+                                                       nullptr, &raw_device),
+               VK_SUCCESS);
+
+    vulkan::VkDevice device(
+        vulkan::CreateDefaultDevice(data->root_allocator, instance, false));
+
+    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000) &&
+        NOT_DEVICE(data->log.get(), device, vulkan::Nvidia965M, 0x5c4f4000)) {
+      device->vkDestroyPipelineCache(
+          device, static_cast<VkPipelineCache>(VK_NULL_HANDLE), nullptr);
+      VkDescriptorPoolSize pool_size = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1};
+      vulkan::VkDescriptorPool pool =
+          CreateDescriptorPool(&device, 1, &pool_size, 1);
+      ::VkDescriptorPool raw_pool = pool.get_raw_object();
+
+      ::VkDescriptorSet sets[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+      device->vkFreeDescriptorSets(device, raw_pool, 2, sets);
+
+      device->vkDestroyBuffer(device, (VkBuffer)VK_NULL_HANDLE, nullptr);
+
+      device->vkDestroyBufferView(device, (VkBufferView)VK_NULL_HANDLE,
+                                  nullptr);
+
+      device->vkDestroyDescriptorSetLayout(
+          device, (VkDescriptorSetLayout)VK_NULL_HANDLE, nullptr);
+
+      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
+
+      device->vkDestroyImageView(device, (VkImageView)VK_NULL_HANDLE, nullptr);
+
+      device->vkDestroyQueryPool(device, (VkQueryPool)VK_NULL_HANDLE, nullptr);
+      device->vkDestroySampler(device, (VkSampler)VK_NULL_HANDLE, nullptr);
+      device->vkDestroyDescriptorPool(device, (VkDescriptorPool)VK_NULL_HANDLE,
+                                      nullptr);
+      device->vkFreeMemory(device, VkDeviceMemory(VK_NULL_HANDLE), nullptr);
+      device->vkDestroyPipelineCache(
+          device, static_cast<VkPipelineCache>(VK_NULL_HANDLE), nullptr);
+
+      device->vkDestroySemaphore(device, (VkSemaphore)VK_NULL_HANDLE, nullptr);
+
+      device->vkDestroyFramebuffer(
+          device, static_cast<VkFramebuffer>(VK_NULL_HANDLE), nullptr);
+      device->vkDestroyPipelineLayout(
+          device, static_cast<VkPipelineLayout>(VK_NULL_HANDLE), nullptr);
+
+      device->vkDestroyRenderPass(
+          device, static_cast<VkRenderPass>(VK_NULL_HANDLE), nullptr);
+
+      device->vkDestroyShaderModule(
+          device, static_cast<VkShaderModule>(VK_NULL_HANDLE), nullptr);
+
+      device->vkDestroyFence(device, (VkFence)VK_NULL_HANDLE, nullptr);
+
+      // These things also fail on Android 7.1
+      if (NOT_ANDROID_VERSION(data, "7.1.1")) {
+        device->vkDestroySwapchainKHR(device, (VkSwapchainKHR)VK_NULL_HANDLE,
+                                      nullptr);
+      }
+    }
+  }
+  data->log->LogInfo("Application Shutdown");
+  return 0;
+}

--- a/gapid_tests/null_destruction_tests/vkDestroyNullHandles/vkDestroyNullHandles_tests.py
+++ b/gapid_tests/null_destruction_tests/vkDestroyNullHandles/vkDestroyNullHandles_tests.py
@@ -1,0 +1,127 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gapit_test_framework import gapit_test, require, require_equal
+from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
+from gapit_test_framework import GapitTest, get_write_offset_function
+from gapit_test_framework import get_read_offset_function
+from vulkan_constants import *
+from struct_offsets import VulkanStruct, UINT32_T, UINT64_T, ARRAY, POINTER, FLOAT
+from gapit_test_framework import NVIDIA_K2200, NVIDIA_965M
+
+
+@gapit_test("vkDestroyNullHandles_test")
+class AllDestroy(GapitTest):
+
+    def expect(self):
+        arch = self.architecture
+        device_properties = require(self.next_call_of(
+            "vkGetPhysicalDeviceProperties"))
+
+        if (self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200) and
+            self.not_device(device_properties, 0x5BCE4000, NVIDIA_965M):
+                destroy_pipeline_cache=require(
+                    self.next_call_of("vkDestroyPipelineCache"))
+                require_not_equal(0, destroy_pipeline_cache.int_device)
+                require_equal(0, destroy_pipeline_cache.int_pipelineCache)
+
+                free_descriptor_set=require(
+                    self.next_call_of("vkFreeDescriptorSets"))
+                p_sets=free_descriptor_set.hex_pDescriptorSets
+                for i in range(2):
+                    actual_set=little_endian_bytes_to_int(
+                        require(free_descriptor_set.get_read_data(
+                            p_sets + NON_DISPATCHABLE_HANDLE_SIZE * i,
+                            NON_DISPATCHABLE_HANDLE_SIZE)))
+                    require_equal(0, actual_set)
+
+                destroy_buffer=require(self.next_call_of("vkDestroyBuffer"))
+                require_not_equal(0, destroy_buffer.int_device)
+                require_equal(0, destroy_buffer.int_buffer)
+
+                destroy_null_buffer_view=require(self.next_call_of(
+                    "vkDestroyBufferView"))
+                require_not_equal(0, destroy_null_buffer_view.int_device)
+                require_equal(0, destroy_null_buffer_view.int_bufferView)
+
+                destroy_descriptor_set_layout=require(self.next_call_of(
+                    "vkDestroyDescriptorSetLayout"))
+                require_equal(0,
+                              destroy_descriptor_set_layout.int_descriptorSetLayout)
+
+                destroy_image=require(self.next_call_of("vkDestroyImage"))
+                require_equal(0, destroy_image.int_image)
+
+                destroy_image_view=require(
+                    self.next_call_of("vkDestroyImageView"))
+                require_equal(0, destroy_image_view.int_imageView)
+
+                destroy_null_query_pool=require(self.next_call_of(
+                    "vkDestroyQueryPool"))
+                require_not_equal(0, destroy_null_query_pool.int_device)
+                require_equal(0, destroy_null_query_pool.int_queryPool)
+
+                destroy_sampler=require(
+                    self.next_call_of("vkDestroySampler"))
+                require_equal(0, destroy_sampler.int_sampler)
+
+                destroy_descriptor_pool=require(
+                    self.next_call_of("vkDestroyDescriptorPool"))
+                require_equal(0, destroy_descriptor_pool.int_descriptorPool)
+
+                free_memory=require(self.next_call_of("vkFreeMemory"))
+                require_not_equal(0, free_memory.int_device)
+                require_equal(0, free_memory.int_memory)
+
+                destroy_pipeline_cache=require(self.next_call_of(
+                    "vkDestroyPipelineCache"))
+                require_not_equal(0, destroy_pipeline_cache.int_device)
+                require_equal(0, destroy_pipeline_cache.int_pipelineCache)
+
+                destroy_semaphore_null=require(
+                    self.next_call_of("vkDestroySemaphore"))
+                require_equal(0, destroy_semaphore_null.int_semaphore)
+
+                destroy_framebuffer=require(
+                    self.next_call_of("vkDestroyFramebuffer"))
+                require_equal(0, destroy_framebuffer.int_framebuffer)
+                require_not_equal(0, destroy_framebuffer.int_device)
+                require_equal(0, destroy_framebuffer.hex_pAllocator)
+
+                destroy_pipeline=require(
+                    self.next_call_of("vkDestroyPipelineLayout"))
+                require_equal(0, destroy_pipeline.int_pipelineLayout)
+                require_not_equal(0, destroy_pipeline.int_device)
+                require_equal(0, destroy_pipeline.hex_pAllocator)
+
+                destroy_render_pass=require(
+                    self.next_call_of("vkDestroyRenderPass"))
+                require_equal(0, destroy_render_pass.int_renderPass)
+                require_not_equal(0, destroy_render_pass.int_device)
+
+                destroy_shader_module=require(
+                    self.next_call_of("vkDestroyShaderModule"))
+                require_not_equal(0, destroy_shader_module.int_device)
+                require_equal(0, destroy_shader_module.int_shaderModule)
+
+                destroy_fence=require(self.next_call_of("vkDestroyFence"))
+                require_not_equal(0, destroy_fence.int_device)
+                require_equal(0, destroy_fence.int_fence)
+                require_equal(0, destroy_fence.hex_pAllocator)
+
+                # Things that fail on android 7.1.1
+                if self.not_android_version("7.1.1"):
+                    destroySwapchain=require(self.next_call_of(
+                        "vkDestroySwapchainKHR"))
+                    require_equal(0, destroySwapchain.int_swapchain)

--- a/gapid_tests/resource_acquisition_tests/vkGetPipelineCacheData_test/main.cpp
+++ b/gapid_tests/resource_acquisition_tests/vkGetPipelineCacheData_test/main.cpp
@@ -76,11 +76,6 @@ int main_entry(const entry::entry_data* data) {
                uint8_t(VK_PIPELINE_CACHE_HEADER_VERSION_ONE));
 
     device->vkDestroyPipelineCache(device, cache, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyPipelineCache(
-          device, static_cast<VkPipelineCache>(VK_NULL_HANDLE), nullptr);
-    }
   }
 
   {

--- a/gapid_tests/resource_acquisition_tests/vkGetPipelineCacheData_test/vkGetPipelineCacheData_test.py
+++ b/gapid_tests/resource_acquisition_tests/vkGetPipelineCacheData_test/vkGetPipelineCacheData_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal, require_true
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function, get_write_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import VulkanStruct, UINT32_T, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -64,12 +63,6 @@ class GetDataOfAnEmptyPipelineCache(GapitTest):
 
         destroy_pipeline_cache = require(
             self.next_call_of("vkDestroyPipelineCache"))
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_pipeline_cache = require(
-                self.next_call_of("vkDestroyPipelineCache"))
-            require_not_equal(0, destroy_pipeline_cache.int_device)
-            require_equal(0, destroy_pipeline_cache.int_pipelineCache)
 
 
 @gapit_test("vkGetPipelineCacheData_test")

--- a/gapid_tests/resource_creation_tests/AllocateFreeDescriptorSets_test/AllocateFreeDescriptorSets_test.py
+++ b/gapid_tests/resource_creation_tests/AllocateFreeDescriptorSets_test/AllocateFreeDescriptorSets_test.py
@@ -16,7 +16,6 @@ from gapit_test_framework import gapit_test, GapitTest, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, HANDLE, POINTER
-from gapit_test_framework import NVIDIA_K2200
 
 DESCRIPTOR_SET_ALLOCATE_INFO_ELEMENTS = [
     ("sType", UINT32_T),
@@ -189,14 +188,3 @@ class FreeNullDescriptorSets(GapitTest):
         """3. Free null descriptor sets."""
         device_properties = require(
             self.next_call_of("vkGetPhysicalDeviceProperties"))
-
-        if (self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200)):
-            free_descriptor_set = require(
-                self.nth_call_of("vkFreeDescriptorSets", 3))
-            p_sets = free_descriptor_set.hex_pDescriptorSets
-            for i in range(2):
-                actual_set = little_endian_bytes_to_int(
-                    require(free_descriptor_set.get_read_data(
-                        p_sets + NON_DISPATCHABLE_HANDLE_SIZE * i,
-                        NON_DISPATCHABLE_HANDLE_SIZE)))
-                require_equal(0, actual_set)

--- a/gapid_tests/resource_creation_tests/AllocateFreeDescriptorSets_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/AllocateFreeDescriptorSets_test/main.cpp
@@ -83,18 +83,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkFreeDescriptorSets(device, raw_pool, kNumSets, sets);
   }
 
-  {  // 3. Destroy null descriptor set handles.
-    VkDescriptorPoolSize pool_size = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1};
-    vulkan::VkDescriptorPool pool =
-        CreateDescriptorPool(&device, 1, &pool_size, 1);
-    ::VkDescriptorPool raw_pool = pool.get_raw_object();
-
-    ::VkDescriptorSet sets[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkFreeDescriptorSets(device, raw_pool, 2, sets);
-    }
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/AllocateResetFreeCommandBuffer/main.cpp
+++ b/gapid_tests/resource_creation_tests/AllocateResetFreeCommandBuffer/main.cpp
@@ -39,7 +39,7 @@ int main_entry(const entry::entry_data* data) {
   uint32_t reset_flag_index = reset_flags.size() - 1;
 
   containers::vector<::VkCommandBuffer> command_buffers(allocator);
-  command_buffers.reserve(max_count);
+  command_buffers.resize(max_count);
   for (VkCommandBufferLevel level :
        vulkan::AllVkCommandBufferLevels(allocator)) {
     for (uint32_t count : {uint32_t(1), uint32_t(2), max_count}) {

--- a/gapid_tests/resource_creation_tests/BufferCreationMemory_test/BufferCreationMemory_test.py
+++ b/gapid_tests/resource_creation_tests/BufferCreationMemory_test/BufferCreationMemory_test.py
@@ -13,7 +13,6 @@ from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function
 from gapit_test_framework import get_write_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import VulkanStruct, UINT32_T, DEVICE_SIZE, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -85,10 +84,3 @@ class BufferCreationDestroy(GapitTest):
         require_equal(destroy_buffer.int_device,
                       get_buffer_memory_requirements.int_device)
         require_equal(written_buffer, destroy_buffer.int_buffer)
-
-        # Our second vkDestroySwapchain should have been called with
-        # VK_NULL_HANDLE
-        if (self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200)):
-            destroy_buffer = require(self.next_call_of("vkDestroyBuffer"))
-            require_not_equal(0, destroy_buffer.int_device)
-            require_equal(0, destroy_buffer.int_buffer)

--- a/gapid_tests/resource_creation_tests/BufferCreationMemory_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/BufferCreationMemory_test/main.cpp
@@ -58,10 +58,6 @@ int main_entry(const entry::entry_data* data) {
     data->log->LogInfo("   TypeBits  :", requirements.memoryTypeBits);
   }
 
-  if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-    device->vkDestroyBuffer(device, (VkBuffer)VK_NULL_HANDLE, nullptr);
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/CreateDestroyBufferView_test/CreateDestroyBufferView_test.py
+++ b/gapid_tests/resource_creation_tests/CreateDestroyBufferView_test/CreateDestroyBufferView_test.py
@@ -15,7 +15,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, GapitTest
 from gapit_test_framework import get_read_offset_function, get_write_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, POINTER, HANDLE, DEVICE_SIZE
 from struct_offsets import ARRAY, CHAR
@@ -75,12 +74,6 @@ class ZeroOffsetWholeSizeBufferViewOfUniformBuffer(GapitTest):
         require_equal(device, destroy_buffer_view.int_device)
         require_equal(view.handle, destroy_buffer_view.int_bufferView)
 
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_null_buffer_view = require(self.next_call_of(
-                "vkDestroyBufferView"))
-            require_equal(device, destroy_buffer_view.int_device)
-            require_equal(0, destroy_null_buffer_view.int_bufferView)
-
 
 @gapit_test("CreateDestroyBufferView_test")
 class NonZeroOffsetNonWholeSizeBufferViewOfStorageBuffer(GapitTest):
@@ -122,9 +115,3 @@ class NonZeroOffsetNonWholeSizeBufferViewOfStorageBuffer(GapitTest):
         destroy_buffer_view = require(self.next_call_of("vkDestroyBufferView"))
         require_equal(device, destroy_buffer_view.int_device)
         require_equal(view.handle, destroy_buffer_view.int_bufferView)
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_null_buffer_view = require(self.next_call_of(
-                "vkDestroyBufferView"))
-            require_equal(device, destroy_buffer_view.int_device)
-            require_equal(0, destroy_null_buffer_view.int_bufferView)

--- a/gapid_tests/resource_creation_tests/CreateDestroyBufferView_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyBufferView_test/main.cpp
@@ -66,11 +66,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkCreateBufferView(device, &view_create_info, nullptr,
                                &buffer_view);
     device->vkDestroyBufferView(device, buffer_view, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyBufferView(device, (VkBufferView)VK_NULL_HANDLE,
-                                  nullptr);
-    }
   }
 
   {
@@ -104,11 +99,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkCreateBufferView(device, &view_create_info, nullptr,
                                &buffer_view);
     device->vkDestroyBufferView(device, buffer_view, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyBufferView(device, (VkBufferView)VK_NULL_HANDLE,
-                                  nullptr);
-    }
   }
 
   data->log->LogInfo("Application Shutdown");

--- a/gapid_tests/resource_creation_tests/CreateDestroyDescriptorSetLayout_test/CreateDestroyDescriptorSetLayout_test.py
+++ b/gapid_tests/resource_creation_tests/CreateDestroyDescriptorSetLayout_test/CreateDestroyDescriptorSetLayout_test.py
@@ -15,7 +15,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, FLOAT, POINTER
 
@@ -141,7 +140,8 @@ class ZeroBindings(GapitTest):
         require_equal(info.bindingCount, 0)
         require_equal(info.pBindings, 0)
 
-        check_destroy_descriptor_set_layout(self, device, descriptor_set_layout)
+        check_destroy_descriptor_set_layout(
+            self, device, descriptor_set_layout)
 
 
 @gapit_test("CreateDestroyDescriptorSetLayout_test")
@@ -175,7 +175,8 @@ class ThreeBindings(GapitTest):
         # The 2nd binding.
         binding = get_binding(create_descriptor_set_layout, arch, info, 1)
         require_equal(binding.binding, 2)
-        require_equal(binding.descriptorType, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        require_equal(binding.descriptorType,
+                      VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
         require_equal(binding.descriptorCount, 1)
         require_equal(binding.stageFlags, VK_SHADER_STAGE_VERTEX_BIT)
         require_equal(binding.pImmutableSamplers, 0)
@@ -183,12 +184,14 @@ class ThreeBindings(GapitTest):
         # The 3rd binding.
         binding = get_binding(create_descriptor_set_layout, arch, info, 2)
         require_equal(binding.binding, 5)
-        require_equal(binding.descriptorType, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+        require_equal(binding.descriptorType,
+                      VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
         require_equal(binding.descriptorCount, 0)
         require_equal(binding.stageFlags, 0xdeadbeef)
         require_equal(binding.pImmutableSamplers, 0)
 
-        check_destroy_descriptor_set_layout(self, device, descriptor_set_layout)
+        check_destroy_descriptor_set_layout(
+            self, device, descriptor_set_layout)
 
 
 @gapit_test("CreateDestroyDescriptorSetLayout_test")
@@ -238,19 +241,5 @@ class TwoBindingsWithSamplers(GapitTest):
                                         binding, i)
             require_equal(expected_samplers[i], sampler)
 
-        check_destroy_descriptor_set_layout(self, device, descriptor_set_layout)
-
-
-@gapit_test("CreateDestroyDescriptorSetLayout_test")
-class DestroyNullDescriptorSetLayout(GapitTest):
-
-    def expect(self):
-        """4. Destroys a null descriptor set layout handle."""
-        device_properties = require(self.next_call_of(
-            "vkGetPhysicalDeviceProperties"))
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_descriptor_set_layout = require(self.nth_call_of(
-                "vkDestroyDescriptorSetLayout", 4))
-            require_equal(0,
-                          destroy_descriptor_set_layout.int_descriptorSetLayout)
+        check_destroy_descriptor_set_layout(
+            self, device, descriptor_set_layout)

--- a/gapid_tests/resource_creation_tests/CreateDestroyDescriptorSetLayout_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyDescriptorSetLayout_test/main.cpp
@@ -124,13 +124,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkDestroyDescriptorSetLayout(device, layout, nullptr);
   }
 
-  {  // 4. Destroy null descriptor set layout handle.
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyDescriptorSetLayout(
-          device, (VkDescriptorSetLayout)VK_NULL_HANDLE, nullptr);
-    }
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/CreateDestroyImageView_test/CreateDestroyImageView_test.py
+++ b/gapid_tests/resource_creation_tests/CreateDestroyImageView_test/CreateDestroyImageView_test.py
@@ -16,7 +16,6 @@ from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest
 from gapit_test_framework import get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, POINTER, HANDLE, BOOL32
 
@@ -92,11 +91,6 @@ def check_destroy_image_view(test, device, image_view, device_properties):
     destroy_image_view = require(test.next_call_of("vkDestroyImageView"))
     require_equal(device, destroy_image_view.int_device)
     require_equal(image_view, destroy_image_view.int_imageView)
-    # Our second vkDestroyImageView should have been called with
-    # VK_NULL_HANDLE
-    if test.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-        destroy_image_view_2 = require(test.next_call_of("vkDestroyImageView"))
-        require_equal(0, destroy_image_view_2.int_imageView)
 
 
 def get_image_view_create_info(create_image_view, architecture):

--- a/gapid_tests/resource_creation_tests/CreateDestroyImageView_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyImageView_test/main.cpp
@@ -86,10 +86,6 @@ int main_entry(const entry::entry_data* data) {
                VK_SUCCESS);
 
     device->vkDestroyImageView(device, image_view, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyImageView(device, (VkImageView)VK_NULL_HANDLE, nullptr);
-    }
   }
 
   data->log->LogInfo("Application Shutdown");

--- a/gapid_tests/resource_creation_tests/CreateDestroyImage_test/CreateDestroyImage_test.py
+++ b/gapid_tests/resource_creation_tests/CreateDestroyImage_test/CreateDestroyImage_test.py
@@ -15,7 +15,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, POINTER
 
@@ -68,10 +67,6 @@ def check_destroy_image(test, device, image, device_properties):
     destroy_image = require(test.next_call_of("vkDestroyImage"))
     require_equal(device, destroy_image.int_device)
     require_equal(image, destroy_image.int_image)
-    # Our second vkDestroyImage should have been called with VK_NULL_HANDLE
-    if test.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-        destroy_image_2 = require(test.next_call_of("vkDestroyImage"))
-        require_equal(0, destroy_image_2.int_image)
 
 
 def get_image_create_info(create_image, architecture):

--- a/gapid_tests/resource_creation_tests/CreateDestroyImage_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyImage_test/main.cpp
@@ -57,10 +57,6 @@ int main_entry(const entry::entry_data* data) {
     ::VkImage image;
     device->vkCreateImage(device, &image_create_info, nullptr, &image);
     device->vkDestroyImage(device, image, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5DD08000)) {
-      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
-    }
   }
 
   {
@@ -90,10 +86,6 @@ int main_entry(const entry::entry_data* data) {
     ::VkImage image;
     device->vkCreateImage(device, &image_create_info, nullptr, &image);
     device->vkDestroyImage(device, image, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5DD08000)) {
-      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
-    }
   }
 
   {
@@ -124,9 +116,6 @@ int main_entry(const entry::entry_data* data) {
     ::VkImage image;
     device->vkCreateImage(device, &image_create_info, nullptr, &image);
     device->vkDestroyImage(device, image, nullptr);
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5DD08000)) {
-      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
-    }
   }
   {
     // 4. Test creating an image with linear tiling that can be used as the
@@ -157,9 +146,6 @@ int main_entry(const entry::entry_data* data) {
     ::VkImage image;
     device->vkCreateImage(device, &image_create_info, nullptr, &image);
     device->vkDestroyImage(device, image, nullptr);
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5DD08000)) {
-      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
-    }
   }
   {
     // 5. Test an image of 3D type with different extent values and
@@ -189,9 +175,6 @@ int main_entry(const entry::entry_data* data) {
     ::VkImage image;
     device->vkCreateImage(device, &image_create_info, nullptr, &image);
     device->vkDestroyImage(device, image, nullptr);
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5DD08000)) {
-      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
-    }
   }
   {
     // 6. Test creating an preinitialized image with multi-sample
@@ -220,9 +203,6 @@ int main_entry(const entry::entry_data* data) {
     ::VkImage image;
     device->vkCreateImage(device, &image_create_info, nullptr, &image);
     device->vkDestroyImage(device, image, nullptr);
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5DD08000)) {
-      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
-    }
   }
   {
     // 7. Test a 1D image
@@ -251,9 +231,6 @@ int main_entry(const entry::entry_data* data) {
     ::VkImage image;
     device->vkCreateImage(device, &image_create_info, nullptr, &image);
     device->vkDestroyImage(device, image, nullptr);
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5DD08000)) {
-      device->vkDestroyImage(device, (VkImage)VK_NULL_HANDLE, nullptr);
-    }
   }
 
   data->log->LogInfo("Application Shutdown");

--- a/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/CreateDestroyQueryPool_test.py
+++ b/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/CreateDestroyQueryPool_test.py
@@ -16,7 +16,6 @@ from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, GapitTest
 from gapit_test_framework import get_read_offset_function, get_write_offset_function
 from gapit_test_framework import GapidUnsupportedException
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, POINTER, HANDLE, DEVICE_SIZE
 from struct_offsets import ARRAY, CHAR
@@ -72,12 +71,6 @@ class OneQueryOcclusionQueryPool(GapitTest):
         require_equal(device, destroy_query_pool.int_device)
         require_equal(view.handle, destroy_query_pool.int_queryPool)
 
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_null_query_pool = require(self.next_call_of(
-                "vkDestroyQueryPool"))
-            require_equal(device, destroy_query_pool.int_device)
-            require_equal(0, destroy_null_query_pool.int_queryPool)
-
 
 @gapit_test("CreateDestroyQueryPool_test")
 class SevenQueriesTimeStampQueryPool(GapitTest):
@@ -118,12 +111,6 @@ class SevenQueriesTimeStampQueryPool(GapitTest):
         require_equal(device, destroy_query_pool.int_device)
         require_equal(view.handle, destroy_query_pool.int_queryPool)
 
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_null_query_pool = require(self.next_call_of(
-                "vkDestroyQueryPool"))
-            require_equal(device, destroy_query_pool.int_device)
-            require_equal(0, destroy_null_query_pool.int_queryPool)
-
 
 @gapit_test("CreateDestroyQueryPool_test")
 class FourQueriesPipelineStatisticsQueryPool(GapitTest):
@@ -161,7 +148,7 @@ class FourQueriesPipelineStatisticsQueryPool(GapitTest):
         require_equal(4, create_info.queryCount)
         require_equal(
             VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT,
-                      create_info.pipelineStatistics)
+            create_info.pipelineStatistics)
 
         view = VulkanStruct(
             architecture, QUERY_POOL, get_write_offset_function(
@@ -171,9 +158,3 @@ class FourQueriesPipelineStatisticsQueryPool(GapitTest):
         destroy_query_pool = require(self.next_call_of("vkDestroyQueryPool"))
         require_equal(device, destroy_query_pool.int_device)
         require_equal(view.handle, destroy_query_pool.int_queryPool)
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_null_query_pool = require(self.next_call_of(
-                "vkDestroyQueryPool"))
-            require_equal(device, destroy_query_pool.int_device)
-            require_equal(0, destroy_null_query_pool.int_queryPool)

--- a/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/main.cpp
@@ -42,9 +42,6 @@ int main_entry(const entry::entry_data* data) {
                                          nullptr, &query_pool),
                VK_SUCCESS);
     device->vkDestroyQueryPool(device, query_pool, nullptr);
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyQueryPool(device, (VkQueryPool)VK_NULL_HANDLE, nullptr);
-    }
   }
 
   {
@@ -67,10 +64,6 @@ int main_entry(const entry::entry_data* data) {
                                          nullptr, &query_pool),
                VK_SUCCESS);
     device->vkDestroyQueryPool(device, query_pool, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyQueryPool(device, (VkQueryPool)VK_NULL_HANDLE, nullptr);
-    }
   }
 
   {
@@ -101,11 +94,6 @@ int main_entry(const entry::entry_data* data) {
                                            nullptr, &query_pool),
                  VK_SUCCESS);
       device->vkDestroyQueryPool(device, query_pool, nullptr);
-      if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200,
-                     0x5bce4000)) {
-        device->vkDestroyQueryPool(device, (VkQueryPool)VK_NULL_HANDLE,
-                                   nullptr);
-      }
     } else {
       data->log->LogInfo(
           "Disabled test due to missing physical device feature: "

--- a/gapid_tests/resource_creation_tests/CreateDestroySampler_test/CreateDestroySampler_test.py
+++ b/gapid_tests/resource_creation_tests/CreateDestroySampler_test/CreateDestroySampler_test.py
@@ -16,7 +16,6 @@ from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_true, require_false
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, FLOAT, POINTER
 
@@ -156,16 +155,3 @@ class UnnormalizedCoordinates(GapitTest):
         require_true(info.unnormalizedCoordinates)
 
         check_destroy_sampler(self, device, sampler)
-
-
-@gapit_test("CreateDestroySampler_test")
-class DestroyNullSampler(GapitTest):
-
-    def expect(self):
-        """3. Destroys a null sampler handle."""
-        device_properties = require(
-            self.nth_call_of("vkGetPhysicalDeviceProperties", 3))
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_sampler = require(self.next_call_of("vkDestroySampler"))
-            require_equal(0, destroy_sampler.int_sampler)

--- a/gapid_tests/resource_creation_tests/CreateDestroySampler_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroySampler_test/main.cpp
@@ -94,14 +94,6 @@ int main_entry(const entry::entry_data* data) {
     }
   }
 
-  {  // 3. Destroy null sampler handle.
-    vulkan::VulkanApplication app(data->root_allocator, data->log.get(), data);
-    vulkan::VkDevice& device = app.device();
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroySampler(device, (VkSampler)VK_NULL_HANDLE, nullptr);
-    }
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/CreateResetDestroyDescriptorPool_test/CreateResetDestroyDescriptorSet_test.py
+++ b/gapid_tests/resource_creation_tests/CreateResetDestroyDescriptorPool_test/CreateResetDestroyDescriptorSet_test.py
@@ -15,7 +15,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, POINTER
 
@@ -159,17 +158,3 @@ class WithFlagMoreDescriptorTypes(GapitTest):
 
         check_reset_descriptor_pool(self, device, descriptor_pool)
         check_destroy_descriptor_pool(self, device, descriptor_pool)
-
-
-@gapit_test("CreateResetDestroyDescriptorPool_test")
-class DestroyNullDescriptorPool(GapitTest):
-
-    def expect(self):
-        """3. Destroys a null descriptor pool handle."""
-        device_properties = require(
-            self.next_call_of("vkGetPhysicalDeviceProperties"))
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_descriptor_pool = require(
-                self.nth_call_of("vkDestroyDescriptorPool", 3))
-            require_equal(0, destroy_descriptor_pool.int_descriptorPool)

--- a/gapid_tests/resource_creation_tests/CreateResetDestroyDescriptorPool_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateResetDestroyDescriptorPool_test/main.cpp
@@ -79,13 +79,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkDestroyDescriptorPool(device, pool, nullptr);
   }
 
-  {  // 3. Destroy null sampler handle.
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyDescriptorPool(device, (VkDescriptorPool)VK_NULL_HANDLE,
-                                      nullptr);
-    }
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/ImageMemory_test/ImageMemory_test.py
+++ b/gapid_tests/resource_creation_tests/ImageMemory_test/ImageMemory_test.py
@@ -16,7 +16,6 @@ from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_write_offset_function
 from gapit_test_framework import get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 from struct_offsets import VulkanStruct, UINT32_T, POINTER, DEVICE_SIZE
 
@@ -89,8 +88,3 @@ class AllocateBindFreeMemory(GapitTest):
         require_not_equal(0, free_memory.int_device)
         require_not_equal(0, free_memory.int_memory)
         require_equal(0, free_memory.hex_pAllocator)
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            free_memory = require(self.next_call_of("vkFreeMemory"))
-            require_not_equal(0, free_memory.int_device)
-            require_equal(0, free_memory.int_memory)

--- a/gapid_tests/resource_creation_tests/ImageMemory_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/ImageMemory_test/main.cpp
@@ -86,10 +86,6 @@ int main_entry(const entry::entry_data* data) {
 
     device->vkFreeMemory(device, device_memory, nullptr);
 
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkFreeMemory(device, VkDeviceMemory(VK_NULL_HANDLE), nullptr);
-    }
   }
   data->log->LogInfo("Application Shutdown");
   return 0;

--- a/gapid_tests/resource_creation_tests/PipelineCache_test/PipelineCache_test.py
+++ b/gapid_tests/resource_creation_tests/PipelineCache_test/PipelineCache_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import VulkanStruct, UINT32_T, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -52,9 +51,3 @@ class EmptyPipelineCache(GapitTest):
 
         require_not_equal(0, destroy_pipeline_cache.int_device)
         require_not_equal(0, destroy_pipeline_cache.int_pipelineCache)
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_pipeline_cache = require(self.next_call_of(
-                "vkDestroyPipelineCache"))
-            require_not_equal(0, destroy_pipeline_cache.int_device)
-            require_equal(0, destroy_pipeline_cache.int_pipelineCache)

--- a/gapid_tests/resource_creation_tests/PipelineCache_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/PipelineCache_test/main.cpp
@@ -39,15 +39,11 @@ int main_entry(const entry::entry_data* data) {
     };
 
     VkPipelineCache cache;
-    LOG_ASSERT(==, data->log, device->vkCreatePipelineCache(
-                                  device, &create_info, nullptr, &cache),
-               VK_SUCCESS);
+    LOG_ASSERT(
+        ==, data->log,
+        device->vkCreatePipelineCache(device, &create_info, nullptr, &cache),
+        VK_SUCCESS);
     device->vkDestroyPipelineCache(device, cache, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyPipelineCache(
-          device, static_cast<VkPipelineCache>(VK_NULL_HANDLE), nullptr);
-    }
   }
 
   data->log->LogInfo("Application Shutdown");

--- a/gapid_tests/resource_creation_tests/SynchronizationCreationDestruction_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/SynchronizationCreationDestruction_test/main.cpp
@@ -36,10 +36,6 @@ int main_entry(const entry::entry_data* data) {
 
   device->vkDestroySemaphore(device, semaphore, nullptr);
 
-  if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-    device->vkDestroySemaphore(device, (VkSemaphore)VK_NULL_HANDLE, nullptr);
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/SynchronizationCreationDestruction_test/vkCreateSemaphore_test.py
+++ b/gapid_tests/resource_creation_tests/SynchronizationCreationDestruction_test/vkCreateSemaphore_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest
-from gapit_test_framework import NVIDIA_K2200
 from vulkan_constants import *
 
 
@@ -61,10 +60,3 @@ class SemaphoreCreateDestroyTest(GapitTest):
         require_equal(
             little_endian_bytes_to_int(returned_semaphore),
             destroy_semaphore.int_semaphore)
-
-        # Our second destroy_semaphore should have been called with
-        # VK_NULL_HANDLE
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_semaphore_null = require(
-                self.next_call_of("vkDestroySemaphore"))
-            require_equal(0, destroy_semaphore_null.int_semaphore)

--- a/gapid_tests/resource_creation_tests/vkCreateFramebuffer_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/vkCreateFramebuffer_test/main.cpp
@@ -137,11 +137,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkDestroyFramebuffer(device, framebuffer, nullptr);
   }
 
-  if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-    device->vkDestroyFramebuffer(
-        device, static_cast<VkFramebuffer>(VK_NULL_HANDLE), nullptr);
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/vkCreateFramebuffer_test/vkCreateFramebuffer_test.py
+++ b/gapid_tests/resource_creation_tests/vkCreateFramebuffer_test/vkCreateFramebuffer_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import VulkanStruct, UINT32_T, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -66,10 +65,3 @@ class SingleAttachment(GapitTest):
         require_not_equal(0, destroy_framebuffer.int_framebuffer)
         require_not_equal(0, destroy_framebuffer.int_device)
         require_equal(0, destroy_framebuffer.hex_pAllocator)
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_framebuffer = require(
-                self.next_call_of("vkDestroyFramebuffer"))
-            require_equal(0, destroy_framebuffer.int_framebuffer)
-            require_not_equal(0, destroy_framebuffer.int_device)
-            require_equal(0, destroy_framebuffer.hex_pAllocator)

--- a/gapid_tests/resource_creation_tests/vkCreatePipelineLayout_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/vkCreatePipelineLayout_test/main.cpp
@@ -50,8 +50,9 @@ int main_entry(const entry::entry_data* data) {
   {
     // Single layout
     vulkan::VkDescriptorSetLayout layout = vulkan::CreateDescriptorSetLayout(
-        data->root_allocator, &device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                                         1, VK_SHADER_STAGE_ALL, nullptr}});
+        data->root_allocator, &device,
+        {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL,
+          nullptr}});
     VkDescriptorSetLayout raw_layouts[1] = {layout};
     VkPipelineLayoutCreateInfo create_info{
         VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,  // sType
@@ -72,11 +73,13 @@ int main_entry(const entry::entry_data* data) {
   {
     // Two layouts
     vulkan::VkDescriptorSetLayout layout = vulkan::CreateDescriptorSetLayout(
-        data->root_allocator, &device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                                         1, VK_SHADER_STAGE_ALL, nullptr}});
+        data->root_allocator, &device,
+        {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL,
+          nullptr}});
     vulkan::VkDescriptorSetLayout layout2 = vulkan::CreateDescriptorSetLayout(
-        data->root_allocator, &device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                                         1, VK_SHADER_STAGE_ALL, nullptr}});
+        data->root_allocator, &device,
+        {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL,
+          nullptr}});
     VkDescriptorSetLayout raw_layouts[2] = {layout, layout2};
 
     VkPipelineLayoutCreateInfo create_info{
@@ -93,14 +96,6 @@ int main_entry(const entry::entry_data* data) {
                device->vkCreatePipelineLayout(device, &create_info, nullptr,
                                               &raw_pipeline_layout));
     device->vkDestroyPipelineLayout(device, raw_pipeline_layout, nullptr);
-  }
-
-  {
-    // Empty destroy
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyPipelineLayout(
-          device, static_cast<VkPipelineLayout>(VK_NULL_HANDLE), nullptr);
-    }
   }
 
   data->log->LogInfo("Application Shutdown");

--- a/gapid_tests/resource_creation_tests/vkCreatePipelineLayout_test/vkCreatePipelineLayout_test.py
+++ b/gapid_tests/resource_creation_tests/vkCreatePipelineLayout_test/vkCreatePipelineLayout_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import VulkanStruct, UINT32_T, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -151,7 +150,7 @@ class TwoLayouts(GapitTest):
 
         _ = require(create_pipeline.get_read_data(
             pipeline_layout_create_info.pSetLayouts +
-                NON_DISPATCHABLE_HANDLE_SIZE,
+            NON_DISPATCHABLE_HANDLE_SIZE,
             NON_DISPATCHABLE_HANDLE_SIZE
         ))
 
@@ -164,7 +163,7 @@ class TwoLayouts(GapitTest):
         set_layout2 = little_endian_bytes_to_int(require(
             create_pipeline.get_read_data(
                 pipeline_layout_create_info.pSetLayouts +
-                    NON_DISPATCHABLE_HANDLE_SIZE,
+                NON_DISPATCHABLE_HANDLE_SIZE,
                 NON_DISPATCHABLE_HANDLE_SIZE)))
         require_not_equal(VK_NULL_HANDLE, set_layout2)
 
@@ -173,18 +172,3 @@ class TwoLayouts(GapitTest):
         require_equal(created_pipeline, destroy_pipeline.int_pipelineLayout)
         require_equal(create_pipeline.int_device, destroy_pipeline.int_device)
         require_equal(0, destroy_pipeline.hex_pAllocator)
-
-
-@gapit_test("vkCreatePipelineLayout_test")
-class NullDestroy(GapitTest):
-
-    def expect(self):
-        device_properties = require(
-            self.next_call_of("vkGetPhysicalDeviceProperties"))
-
-        if (self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200)):
-            destroy_pipeline = require(
-                self.nth_call_of("vkDestroyPipelineLayout", 4))
-            require_equal(0, destroy_pipeline.int_pipelineLayout)
-            require_not_equal(0, destroy_pipeline.int_device)
-            require_equal(0, destroy_pipeline.hex_pAllocator)

--- a/gapid_tests/resource_creation_tests/vkCreateRenderPass_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/vkCreateRenderPass_test/main.cpp
@@ -125,11 +125,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkDestroyRenderPass(device, raw_render_pass, nullptr);
   }
 
-  if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-    device->vkDestroyRenderPass(
-        device, static_cast<VkRenderPass>(VK_NULL_HANDLE), nullptr);
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/vkCreateRenderPass_test/vkCreateRenderPass_test.py
+++ b/gapid_tests/resource_creation_tests/vkCreateRenderPass_test/vkCreateRenderPass_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import VulkanStruct, UINT32_T, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -163,9 +162,3 @@ class SingleAttachment(GapitTest):
 
         require_not_equal(0, destroy_render_pass.int_renderPass)
         require_not_equal(0, destroy_render_pass.int_device)
-
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_render_pass = require(
-                self.next_call_of("vkDestroyRenderPass"))
-            require_equal(0, destroy_render_pass.int_renderPass)
-            require_not_equal(0, destroy_render_pass.int_device)

--- a/gapid_tests/resource_creation_tests/vkCreateShaderModule_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/vkCreateShaderModule_test/main.cpp
@@ -49,11 +49,6 @@ int main_entry(const entry::entry_data* data) {
                                             &shader_module),
                VK_SUCCESS);
     device->vkDestroyShaderModule(device, shader_module, nullptr);
-
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyShaderModule(
-          device, static_cast<VkShaderModule>(VK_NULL_HANDLE), nullptr);
-    }
   }
 
   data->log->LogInfo("Application Shutdown");

--- a/gapid_tests/resource_creation_tests/vkCreateShaderModule_test/vkCreateShaderModule_test.py
+++ b/gapid_tests/resource_creation_tests/vkCreateShaderModule_test/vkCreateShaderModule_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import VulkanStruct, UINT32_T, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -52,11 +51,3 @@ class ShaderModuleTest(GapitTest):
 
         require_not_equal(0, destroy_shader_module.int_device)
         require_not_equal(0, destroy_shader_module.int_shaderModule)
-
-        # Our second vkDestroySwapchain should have been called with
-        # VK_NULL_HANDLE
-        if self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200):
-            destroy_shader_module = require(
-                self.next_call_of("vkDestroyShaderModule"))
-            require_not_equal(0, destroy_shader_module.int_device)
-            require_equal(0, destroy_shader_module.int_shaderModule)

--- a/gapid_tests/resource_creation_tests/vkCreateSwapchainKHR_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/vkCreateSwapchainKHR_test/main.cpp
@@ -117,12 +117,6 @@ int main_entry(const entry::entry_data* data) {
   data->log->LogInfo("Vendor ID: ", device.vendor_id());
   data->log->LogInfo("driver version: ", device.driver_version());
 
-  if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000) &&
-      NOT_ANDROID_VERSION(data, "7.1.1")) {
-    device->vkDestroySwapchainKHR(device, (VkSwapchainKHR)VK_NULL_HANDLE,
-                                  nullptr);
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/gapid_tests/resource_creation_tests/vkCreateSwapchainKHR_test/vkCreateSwapchainKHR_test.py
+++ b/gapid_tests/resource_creation_tests/vkCreateSwapchainKHR_test/vkCreateSwapchainKHR_test.py
@@ -11,7 +11,7 @@
 
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
-from gapit_test_framework import GapitTest, NVIDIA_K2200
+from gapit_test_framework import GapitTest
 from struct_offsets import VulkanStruct, UINT32_T, SIZE_T, POINTER
 from struct_offsets import HANDLE, FLOAT, CHAR, ARRAY
 from vulkan_constants import *
@@ -54,7 +54,7 @@ class SwapchainCreateTest(GapitTest):
              ("presentMode", UINT32_T),
              ("clipped", UINT32_T),
              ("oldSwapchain", HANDLE)  # oldSwapchain
-            ],
+             ],
             get_swapchain_create_info_member)
 
         require_equal(swapchain_create_info.sType,
@@ -66,11 +66,3 @@ class SwapchainCreateTest(GapitTest):
         require_not_equal(0, destroySwapchain.int_swapchain)
         require_equal(True, (swapchain_create_info.queueFamilyIndexCount == 0 or
                              swapchain_create_info.queueFamilyIndexCount == 2))
-
-        # Our second vkDestroySwapchain should have been called with
-        # VK_NULL_HANDLE.
-        if (self.not_device(device_properties, 0x5BCE4000, NVIDIA_K2200) and
-                self.not_android_version("7.1.1")):
-            destroySwapchain = require(self.next_call_of(
-                "vkDestroySwapchainKHR"))
-            require_equal(0, destroySwapchain.int_swapchain)

--- a/gapid_tests/synchronization_tests/Fence_test/Fence_test.py
+++ b/gapid_tests/synchronization_tests/Fence_test/Fence_test.py
@@ -12,7 +12,6 @@
 from gapit_test_framework import gapit_test, require, require_equal
 from gapit_test_framework import require_not_equal, little_endian_bytes_to_int
 from gapit_test_framework import GapitTest, get_read_offset_function
-from gapit_test_framework import NVIDIA_K2200
 from struct_offsets import *
 from vulkan_constants import *
 
@@ -41,7 +40,7 @@ class CreateDestroyWaitTest(GapitTest):
 
         create_info = VulkanStruct(architecture,
                                    FENCE_CREATE_INFO, get_read_offset_function(
-                                   create_fence, create_fence.hex_pCreateInfo))
+                                       create_fence, create_fence.hex_pCreateInfo))
 
         require_equal(VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, create_info.sType)
         require_equal(0, create_info.pNext)
@@ -97,18 +96,3 @@ class GetFenceStatus(GapitTest):
         require(self.next_call_of("vkCreateFence"))
         fourth_get_status = require(self.next_call_of("vkGetFenceStatus"))
         require_equal(VK_SUCCESS, (fourth_get_status.return_val))
-
-
-@gapit_test("Fence_test")
-class DestroyEmpty(GapitTest):
-
-    def expect(self):
-
-        device_properties = require(
-            self.next_call_of("vkGetPhysicalDeviceProperties"))
-
-        if self.not_device(device_properties, 0x5DD08000, NVIDIA_K2200):
-            destroy_fence = require(self.nth_call_of("vkDestroyFence", 4))
-            require_not_equal(0, destroy_fence.int_device)
-            require_equal(0, destroy_fence.int_fence)
-            require_equal(0, destroy_fence.hex_pAllocator)

--- a/gapid_tests/synchronization_tests/Fence_test/main.cpp
+++ b/gapid_tests/synchronization_tests/Fence_test/main.cpp
@@ -49,24 +49,21 @@ int main_entry(const entry::entry_data* data) {
     device->vkDestroyFence(device, fence, nullptr);
   }
 
-  { // Get fence status
+  {  // Get fence status
     vulkan::VkFence fence = vulkan::CreateFence(&device, false);
-    LOG_ASSERT(==, data->log.get(), VK_NOT_READY, device->vkGetFenceStatus(device, fence));
+    LOG_ASSERT(==, data->log.get(), VK_NOT_READY,
+               device->vkGetFenceStatus(device, fence));
     render_queue->vkQueueSubmit(render_queue, 0, nullptr, fence);
     render_queue->vkQueueWaitIdle(render_queue);
-    LOG_ASSERT(==, data->log.get(), VK_SUCCESS, device->vkGetFenceStatus(device, fence));
+    LOG_ASSERT(==, data->log.get(), VK_SUCCESS,
+               device->vkGetFenceStatus(device, fence));
     device->vkResetFences(device, 1, &fence.get_raw_object());
-    LOG_ASSERT(==, data->log.get(), VK_NOT_READY, device->vkGetFenceStatus(device, fence));
+    LOG_ASSERT(==, data->log.get(), VK_NOT_READY,
+               device->vkGetFenceStatus(device, fence));
 
     vulkan::VkFence fence_signaled = vulkan::CreateFence(&device, true);
-    LOG_ASSERT(==, data->log.get(), VK_SUCCESS, device->vkGetFenceStatus(device, fence_signaled));
-  }
-
-  {  // Destroy empty fence
-    // Destroying a null fence handle crashes on Nvidia driver 375.66
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5dd08000)) {
-      device->vkDestroyFence(device, (VkFence)VK_NULL_HANDLE, nullptr);
-    }
+    LOG_ASSERT(==, data->log.get(), VK_SUCCESS,
+               device->vkGetFenceStatus(device, fence_signaled));
   }
 
   data->log->LogInfo("Application Shutdown");

--- a/gapid_tests/synchronization_tests/vkDeviceWaitIdle_test/main.cpp
+++ b/gapid_tests/synchronization_tests/vkDeviceWaitIdle_test/main.cpp
@@ -48,12 +48,6 @@ int main_entry(const entry::entry_data* data) {
     device->vkDestroyFence(device, fence, nullptr);
   }
 
-  {  // Destroy empty fence
-    if (NOT_DEVICE(data->log.get(), device, vulkan::NvidiaK2200, 0x5bce4000)) {
-      device->vkDestroyFence(device, (VkFence)VK_NULL_HANDLE, nullptr);
-    }
-  }
-
   data->log->LogInfo("Application Shutdown");
   return 0;
 }

--- a/support/entry/entry.cpp
+++ b/support/entry/entry.cpp
@@ -277,7 +277,7 @@ int main(int argc, const char** argv) {
         GetEnvironmentVariableA("VK_LAYER_PATH", layer_path, 1024 * 1024 - 1);
     std::string lp = layer_path;
     if (d > 0 && !lp.empty()) {
-      lp = lp + ":" + file_path;
+      lp = lp + ";" + file_path;
     } else {
       lp = file_path;
     }

--- a/tools/gapit_test_framework.py
+++ b/tools/gapit_test_framework.py
@@ -39,6 +39,7 @@ SKIPPED = 3
 
 PIXEL_C = {"vendor_id": 0x10DE, "device_id": 0x92BA03D7}
 NVIDIA_K2200 = {"vendor_id": 0x10DE, "device_id": 0x13ba}
+NVIDIA_965M = {"vendor_id": 0x10DE, "device_id": 0x1427}
 
 UNKNOWN_OS, WINDOWS, OSX, LINUX, ANDROID = range(5)
 
@@ -326,7 +327,7 @@ class GapitTest(object):
             else:
                 subprocess.check_call(
                     gapit_args, stdout=open(os.devnull, 'wb'),
-                                stderr=open(os.devnull, 'wb'))
+                    stderr=open(os.devnull, 'wb'))
         except:
             return (FAILURE, "Could not generate trace file.")
         if verbose:
@@ -356,7 +357,8 @@ class GapitTest(object):
             if not success == SUCCESS:
                 return (success, error)
         test_name = program_name + "." + self.name()
-        self.device, self.architecture = get_device_and_architecture_info_from_trace_file(capture_name)
+        self.device, self.architecture = get_device_and_architecture_info_from_trace_file(
+            capture_name)
         if self.architecture is None:
             return (FAILURE, "Failed to obtain device architecture info from trace")
         self.atom_generator = parse_trace_file(capture_name)

--- a/tools/gapit_trace_reader.py
+++ b/tools/gapit_trace_reader.py
@@ -411,9 +411,11 @@ def next_line(proc):
         line = proc.stdout.readline()
         if line == '\n':
             continue
+        if line == '\r\n':
+            continue
         if re.match(r'\d\d?:\d\d?:\d\d?\.\d*.* <gapi\w>', line):
             continue
-        return line.strip()
+        return line.strip("\r\n").strip()
 
 
 def get_device_and_architecture_info_from_trace_file(filename):
@@ -438,7 +440,7 @@ def get_device_and_architecture_info_from_trace_file(filename):
             if line == '':
                 return None
         # append the ending '}'
-        return_str += line
+        return_str += line.strip() + "\n"
         return return_str
 
     device = None

--- a/tools/gapit_trace_reader.py
+++ b/tools/gapit_trace_reader.py
@@ -308,7 +308,7 @@ def parse_atom_line(line):
 
     This is expected to be first line of a new atom
     '''
-    match = re.match(r'\[(\d+)\] ([a-zA-Z]*)\((.*)\)(?: → (.*))?', line)
+    match = re.match(r'\[(\d+)\] ([a-zA-Z0-9]*)\((.*)\)(?: → (.*))?', line)
     if not match:
         print 'failed line:: "{}"'.format(line)
     number = int(match.group(1))

--- a/vulkan_helpers/known_device_infos.cpp
+++ b/vulkan_helpers/known_device_infos.cpp
@@ -17,5 +17,6 @@
 
 namespace vulkan {
 const DeviceInfo PixelC{0x10DE, 0x92BA03D7};
-const DeviceInfo NvidiaK2200{0x10DE, 0x13ba};
+const DeviceInfo NvidiaK2200{0x10DE, 0x13BA};
+const DeviceInfo Nvidia965M{0x10DE, 0x1427};
 }  // namespace vulkan

--- a/vulkan_helpers/known_device_infos.h
+++ b/vulkan_helpers/known_device_infos.h
@@ -30,6 +30,7 @@ struct DeviceInfo {
 
 extern const DeviceInfo PixelC;
 extern const DeviceInfo NvidiaK2200;
+extern const DeviceInfo Nvidia965M;
 }
 
 namespace {

--- a/vulkan_helpers/vulkan_application.cpp
+++ b/vulkan_helpers/vulkan_application.cpp
@@ -225,10 +225,9 @@ VulkanApplication::VulkanApplication(
         VK_IMAGE_LAYOUT_UNDEFINED,            // initialLayout
     };
     ::VkImage image;
-    LOG_ASSERT(
-        ==, log_,
-        device_->vkCreateImage(device_, &image_create_info, nullptr, &image),
-        VK_SUCCESS);
+    LOG_ASSERT(==, log_, device_->vkCreateImage(device_, &image_create_info,
+                                                nullptr, &image),
+               VK_SUCCESS);
     VkMemoryRequirements requirements;
     device_->vkGetImageMemoryRequirements(device_, image, &requirements);
     device_->vkDestroyImage(device_, image, nullptr);
@@ -899,9 +898,9 @@ AllocationToken* VulkanArena::AllocateMemory(::VkDeviceSize size,
     }
     token->prev = new_token;
     new_token->next = token;
-	if (first_block_ == token) {
-		first_block_ = new_token;
-	}
+    if (first_block_ == token) {
+      first_block_ = new_token;
+    }
   } else {
     // token happens to now be an empty block. So let's not put it back.
     if (token->next) {
@@ -925,8 +924,10 @@ AllocationToken* VulkanArena::AllocateMemory(::VkDeviceSize size,
 }
 
 void VulkanArena::FreeMemory(AllocationToken* token) {
-	// First try to coalesce this with its previous block.
+  bool atAll = false;
+  // First try to coalesce this with its previous block.
   while (token->prev && !token->prev->in_use) {
+    atAll = true;
     // Take the previous token out of the map, and merge it with this one.
     AllocationToken* prev_token = token->prev;
     prev_token->allocationSize += token->allocationSize;
@@ -942,6 +943,7 @@ void VulkanArena::FreeMemory(AllocationToken* token) {
   }
   // Now try to coalesce this with any subsequent blocks.
   while (token->next && !token->next->in_use) {
+    atAll = true;
     // Take the previous token out of the map, and merge it with this one.
     AllocationToken* next_token = token->next;
     token->allocationSize += next_token->allocationSize;


### PR DESCRIPTION
1) Fix an out-of-bounds vector read.
2) Use the correct path separator for windows VK_LAYER_PATH.
3) Handle \r\n in gapit_trace_reader.py