### PR TITLE
Enable spec constant overrides for compute shaders

### DIFF
--- a/vulkan_helpers/vulkan_application.cpp
+++ b/vulkan_helpers/vulkan_application.cpp
@@ -1251,7 +1251,7 @@ VulkanComputePipeline::VulkanComputePipeline(
     containers::Allocator* allocator, PipelineLayout* layout,
     VulkanApplication* application,
     const VkShaderModuleCreateInfo& shader_module_create_info,
-    const char* shader_entry)
+    const char* shader_entry, const VkSpecializationInfo* specialization_info)
     : application_(application),
       pipeline_(VK_NULL_HANDLE, nullptr, &application->device()),
       shader_module_(VK_NULL_HANDLE, nullptr, &application->device()),
@@ -1269,7 +1269,7 @@ VulkanComputePipeline::VulkanComputePipeline(
       VK_SHADER_STAGE_COMPUTE_BIT,                          // stage
       shader_module_,                                       // module
       shader_entry,                                         // name
-      nullptr  // pSpecializationInfo
+      specialization_info                                   // pSpecializationInfo
   };
 
   VkComputePipelineCreateInfo pipeline_create_info{

--- a/vulkan_helpers/vulkan_application.h
+++ b/vulkan_helpers/vulkan_application.h
@@ -192,7 +192,8 @@ class VulkanComputePipeline {
       containers::Allocator* allocator, PipelineLayout* layout,
       VulkanApplication* application,
       const VkShaderModuleCreateInfo& shader_module_create_info,
-      const char* shader_entry);
+      const char* shader_entry,
+      const VkSpecializationInfo* specialization_info = nullptr);
   VulkanComputePipeline(VulkanComputePipeline&& other) = default;
 
   operator ::VkPipeline() const { return pipeline_; }
@@ -677,9 +678,11 @@ class VulkanApplication {
   VulkanComputePipeline CreateComputePipeline(
       PipelineLayout* layout,
       const VkShaderModuleCreateInfo& shader_module_create_info,
-      const char* shader_entry) {
+      const char* shader_entry,
+      const VkSpecializationInfo* specialization_info = nullptr) {
     return VulkanComputePipeline(allocator_, layout, this,
-                                 shader_module_create_info, shader_entry);
+                                 shader_module_create_info, shader_entry,
+                                 specialization_info);
   }
 
   bool should_exit() const { return should_exit_.load(); }


### PR DESCRIPTION
I used this in my own experimentation, e.g. in the tiny_compute_glsl example in 
https://github.com/dneto0/vulkan_test_applications/tree/tiny_compute_read_workgroup_size_defaulted_to_1

I didn't add support for specialization in graphics pipelines.