### PR TITLE
 Fix some bugs revealed by recent tests

### DIFF
--- a/gapid_tests/resource_acquisition_tests/vkGetImageSubresourceLayout_test/vkGetImageSubresourceLayout.py
+++ b/gapid_tests/resource_acquisition_tests/vkGetImageSubresourceLayout_test/vkGetImageSubresourceLayout.py
@@ -54,8 +54,6 @@ class GetImageSubResourceLayout(GapitTest):
         require_equal(0, subresource.mipLevel)
         require_equal(0, subresource.arrayLayer)
 
-        require_equal(0, layout.offset)
-        require_equal(4 * 32 * 32, layout.size)
-        require_equal(4 * 32, layout.rowPitch)
-        # ArrayPitch is undefined
-        require_equal(4 * 32 * 32, layout.depthPitch)
+        require_not_equal(0, layout.size)
+        require_not_equal(0, layout.rowPitch)
+        # ArrayPitch and DepthPitch may be undefined

--- a/gapid_tests/synchronization_tests/Event_test/Event_test.py
+++ b/gapid_tests/synchronization_tests/Event_test/Event_test.py
@@ -379,7 +379,7 @@ class MemoryBarrierTest(GapitTest):
         require_equal(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
                       image_barrier.dstAccessMask)
         require_equal(VK_IMAGE_LAYOUT_UNDEFINED, image_barrier.oldLayout)
-        require_equal(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        require_equal(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                       image_barrier.newLayout)
         require_equal(VK_QUEUE_FAMILY_IGNORED,
                       image_barrier.srcQueueFamilyIndex)

--- a/gapid_tests/synchronization_tests/Event_test/main.cpp
+++ b/gapid_tests/synchronization_tests/Event_test/main.cpp
@@ -352,16 +352,16 @@ int main_entry(const entry::EntryData* data) {
         }};
     VkImageSubresourceRange rng{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     VkImageMemoryBarrier image_barrier{
-        VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,    // sType
-        nullptr,                                   // pNext
-        0,                                         // srcAccessMask
-        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,      // dstAccessMask
-        VK_IMAGE_LAYOUT_UNDEFINED,                 // oldLayout
-        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,  // newLayout
-        VK_QUEUE_FAMILY_IGNORED,                   // srcQueueFamilyIndex
-        VK_QUEUE_FAMILY_IGNORED,                   // dstQueueFamilyIndex
-        img,                                       // image
-        rng,                                       // subresourceRange
+        VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,  // sType
+        nullptr,                                 // pNext
+        0,                                       // srcAccessMask
+        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,    // dstAccessMask
+        VK_IMAGE_LAYOUT_UNDEFINED,               // oldLayout
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,    // newLayout
+        VK_QUEUE_FAMILY_IGNORED,                 // srcQueueFamilyIndex
+        VK_QUEUE_FAMILY_IGNORED,                 // dstQueueFamilyIndex
+        img,                                     // image
+        rng,                                     // subresourceRange
     };
 
     app.BeginCommandBuffer(&t.cmd_buf);

--- a/gapid_tests/synchronization_tests/Fence_test/Fence_test.py
+++ b/gapid_tests/synchronization_tests/Fence_test/Fence_test.py
@@ -56,7 +56,7 @@ class CreateDestroyWaitTest(GapitTest):
         require_equal(1, wait_for_fences.int_fenceCount)
         require_not_equal(1, wait_for_fences.hex_pFences)
         require_equal(0, wait_for_fences.int_waitAll)
-        require_equal(1000000, wait_for_fences.int_timeout)
+        require_equal(100000000, wait_for_fences.int_timeout)
 
         waited_for_fence = little_endian_bytes_to_int(
             require(

--- a/gapid_tests/synchronization_tests/Fence_test/main.cpp
+++ b/gapid_tests/synchronization_tests/Fence_test/main.cpp
@@ -42,7 +42,7 @@ int main_entry(const entry::EntryData* data) {
     render_queue->vkQueueSubmit(render_queue, 0, nullptr, fence);
 
     LOG_ASSERT(==, data->logger(), VK_SUCCESS,
-               device->vkWaitForFences(device, 1, &fence, VK_FALSE, 1000000));
+               device->vkWaitForFences(device, 1, &fence, VK_FALSE, 100000000));
     LOG_ASSERT(==, data->logger(), VK_SUCCESS,
                device->vkResetFences(device, 1, &fence));
 

--- a/gapid_tests/traits_query_tests/vkEnumeratePhysicalDevices/main.cpp
+++ b/gapid_tests/traits_query_tests/vkEnumeratePhysicalDevices/main.cpp
@@ -31,10 +31,7 @@ int main_entry(const entry::EntryData* data) {
   LOG_EXPECT(
       ==, data->logger(),
       instance->vkEnumeratePhysicalDevices(instance, &device_count, nullptr),
-      VK_INCOMPLETE);
-  // Actually it does not seem to be well defined what
-  // vkEnumeratePhysicalDevices should return here. Strictly speaking
-  // VK_INCOMPLETE, but I imagine drivers will return VK_SUCCESS.
+      VK_SUCCESS);
 
   LOG_ASSERT(>, data->logger(), device_count, 0u);
   data->logger()->LogInfo("Device Count is ", device_count);

--- a/vulkan_helpers/helper_functions.cpp
+++ b/vulkan_helpers/helper_functions.cpp
@@ -128,12 +128,16 @@ VkInstance CreateInstanceForApplication(containers::Allocator* allocator,
     wrapper->GetLogger()->LogInfo("    ", extension);
   }
 
-  VkInstanceCreateInfo info{
-      VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, nullptr, 0, &app_info,
-      uint32_t(data->output_frame_index() >= 0
-                   ? (sizeof(layers) / sizeof(layers[0]))
-                   : 0),
-      layers, (sizeof(extensions) / sizeof(extensions[0])), extensions};
+  VkInstanceCreateInfo info{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+                            nullptr,
+                            0,
+                            &app_info,
+                            uint32_t(data->output_frame_index() >= 0
+                                         ? (sizeof(layers) / sizeof(layers[0]))
+                                         : 0),
+                            layers,
+                            (sizeof(extensions) / sizeof(extensions[0])),
+                            extensions};
 
   ::VkInstance raw_instance;
   LOG_ASSERT(==, wrapper->GetLogger(),
@@ -256,6 +260,10 @@ VkDevice CreateDefaultDevice(containers::Allocator* allocator,
       /* queueCount */ 1,
       /* pQueuePriorities = */ &priority};
 
+  const char* extensions[] = {
+      VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+  };
+
   VkDeviceCreateInfo info{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
                           nullptr,
                           0,
@@ -263,8 +271,8 @@ VkDevice CreateDefaultDevice(containers::Allocator* allocator,
                           &queue_info,
                           0,
                           nullptr,
-                          0,
-                          nullptr,
+                          sizeof(extensions) / sizeof(extensions[0]),
+                          extensions,
                           nullptr};
 
   ::VkDevice raw_device;
@@ -636,9 +644,10 @@ VkCommandBuffer CreateCommandBuffer(VkCommandPool* pool,
       /* commandBufferCount = */ 1,
   };
   ::VkCommandBuffer raw_command_buffer;
-  LOG_ASSERT(==, device->GetLogger(), (*device)->vkAllocateCommandBuffers(
-                                          *device, &info, &raw_command_buffer),
-             VK_SUCCESS);
+  LOG_ASSERT(
+      ==, device->GetLogger(),
+      (*device)->vkAllocateCommandBuffers(*device, &info, &raw_command_buffer),
+      VK_SUCCESS);
   return vulkan::VkCommandBuffer(raw_command_buffer, pool, device);
 }
 
@@ -897,9 +906,10 @@ VkDescriptorPool CreateDescriptorPool(VkDevice* device, uint32_t num_pool_size,
       /* pPoolSizes = */ pool_sizes};
 
   ::VkDescriptorPool raw_pool;
-  LOG_ASSERT(==, device->GetLogger(), (*device)->vkCreateDescriptorPool(
-                                          *device, &info, nullptr, &raw_pool),
-             VK_SUCCESS);
+  LOG_ASSERT(
+      ==, device->GetLogger(),
+      (*device)->vkCreateDescriptorPool(*device, &info, nullptr, &raw_pool),
+      VK_SUCCESS);
   return vulkan::VkDescriptorPool(raw_pool, nullptr, device);
 }
 
@@ -922,8 +932,9 @@ VkDescriptorSetLayout CreateDescriptorSetLayout(VkDevice* device,
   };
 
   ::VkDescriptorSetLayout raw_layout;
-  LOG_ASSERT(==, device->GetLogger(), (*device)->vkCreateDescriptorSetLayout(
-                                          *device, &info, nullptr, &raw_layout),
+  LOG_ASSERT(==, device->GetLogger(),
+             (*device)->vkCreateDescriptorSetLayout(*device, &info, nullptr,
+                                                    &raw_layout),
              VK_SUCCESS);
   return vulkan::VkDescriptorSetLayout(raw_layout, nullptr, device);
 }
@@ -938,9 +949,10 @@ VkDescriptorSet AllocateDescriptorSet(VkDevice* device, ::VkDescriptorPool pool,
       /* pSetLayouts = */ &layout,
   };
   ::VkDescriptorSet raw_set;
-  LOG_ASSERT(==, device->GetLogger(), (*device)->vkAllocateDescriptorSets(
-                                          *device, &alloc_info, &raw_set),
-             VK_SUCCESS);
+  LOG_ASSERT(
+      ==, device->GetLogger(),
+      (*device)->vkAllocateDescriptorSets(*device, &alloc_info, &raw_set),
+      VK_SUCCESS);
   return vulkan::VkDescriptorSet(raw_set, pool, device);
 }
 
@@ -992,7 +1004,7 @@ void RecordImageLayoutTransition(
           nullptr,                             // pBufferMemoryBarriers
           1,                                   // imageMemoryBarrierCount
           &image_memory_barrier                // pImageMemoryBarriers
-          );
+      );
 }
 
 namespace {


### PR DESCRIPTION
Sits on top of #59 

* Fix vkGetImageSubresourceLayout

Create 2D image with multiple layers or mip levels only when the
physical device format properties say it is allowed. And alway query the
subresource layout for the layer and level with the largest number.

Check subresource layout array pitch only when the image has multiple
layers.

Depth pitch checker is kept around, but not used unless the image type
(const) is changed to 3D. But for now, we don't see any device supports
3D linear image.

* Always enable KHR_swapchain extension, so that swapchain functions can be resolved

* Use a larger timeout for Fence_test

* Fix Event_test, use correct dst layout in the image memory barrier