### PR TITLE
Add instance extensions to application framework

### DIFF
--- a/application_sandbox/copy_image_2d3d/main.cpp
+++ b/application_sandbox/copy_image_2d3d/main.cpp
@@ -66,7 +66,7 @@ class CopyImage2D3DSample
             128,  // Larger device buffer space may be required
             // if the swapchain image is large
             1, sample_application::SampleOptions(), VkPhysicalDeviceFeatures{},
-            {"VK_KHR_maintenance1"}),
+            {}, {VK_KHR_MAINTENANCE1_EXTENSION_NAME}),
         cube_(data->allocator(), data->logger(), cube_data) {}
   virtual void InitializeApplicationData(
       vulkan::VkCommandBuffer* initialization_buffer,

--- a/application_sandbox/draw_indexed_indirect_count/main.cpp
+++ b/application_sandbox/draw_indexed_indirect_count/main.cpp
@@ -47,15 +47,15 @@ struct DrawIndexedIndirectCountData {
 
 // This creates an application with 16MB of image memory, and defaults
 // for host, and device buffer sizes.
-class DrawIndexedIndirectCountSample : public sample_application::Sample<DrawIndexedIndirectCountData> {
+class DrawIndexedIndirectCountSample
+    : public sample_application::Sample<DrawIndexedIndirectCountData> {
  public:
   DrawIndexedIndirectCountSample(const entry::EntryData* data)
       : data_(data),
         Sample<DrawIndexedIndirectCountData>(
             data->allocator(), data, 1, 512, 1, 1,
-            sample_application::SampleOptions(), {0},
-            {"VK_KHR_draw_indirect_count"}
-        ),
+            sample_application::SampleOptions(), {0}, {},
+            {VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME}),
         cube_(data->allocator(), data->logger(), cube_data) {}
   virtual void InitializeApplicationData(
       vulkan::VkCommandBuffer* initialization_buffer,
@@ -115,9 +115,8 @@ class DrawIndexedIndirectCountSample : public sample_application::Sample<DrawInd
             ));
 
     cube_pipeline_ = containers::make_unique<vulkan::VulkanGraphicsPipeline>(
-        data_->allocator(),
-        app()->CreateGraphicsPipeline(pipeline_layout_.get(),
-                                      render_pass_.get(), 0));
+        data_->allocator(), app()->CreateGraphicsPipeline(
+                                pipeline_layout_.get(), render_pass_.get(), 0));
     cube_pipeline_->AddShader(VK_SHADER_STAGE_VERTEX_BIT, "main",
                               diic_vertex_shader);
     cube_pipeline_->AddShader(VK_SHADER_STAGE_FRAGMENT_BIT, "main",
@@ -147,38 +146,35 @@ class DrawIndexedIndirectCountSample : public sample_application::Sample<DrawInd
     model_data_->data().transform = Mat44::FromTranslationVector(
         mathfu::Vector<float, 3>{0.0f, 0.0f, -3.0f});
 
-    
     static const uint32_t num_commands = 1;
     VkDrawIndexedIndirectCommand commands[num_commands] = {
-        VkDrawIndexedIndirectCommand {
-            static_cast<uint32_t>(cube_.NumIndices()),// index count
-            1, // instance count
-            0, // firstIndex
-            0, // vertexOffset
-            0, // firstInstance
-        }
-    };
+        VkDrawIndexedIndirectCommand{
+            static_cast<uint32_t>(cube_.NumIndices()),  // index count
+            1,                                          // instance count
+            0,                                          // firstIndex
+            0,                                          // vertexOffset
+            0,                                          // firstInstance
+        }};
 
-    drawDataBuffer = app()->CreateAndBindDefaultExclusiveDeviceBuffer(sizeof(commands),
+    drawDataBuffer = app()->CreateAndBindDefaultExclusiveDeviceBuffer(
+        sizeof(commands),
         VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
-    countDataBuffer = app()->CreateAndBindDefaultExclusiveDeviceBuffer(4,
+    countDataBuffer = app()->CreateAndBindDefaultExclusiveDeviceBuffer(
+        4,
         VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
 
-    app()->FillSmallBuffer(
-        drawDataBuffer.get(), commands,
-        sizeof(commands), 0,
-        initialization_buffer,
-        VK_ACCESS_INDIRECT_COMMAND_READ_BIT);
-    
-    app()->FillSmallBuffer(
-        countDataBuffer.get(), &num_commands,
-        sizeof(num_commands), 0,
-        initialization_buffer,
-        VK_ACCESS_INDIRECT_COMMAND_READ_BIT);
+    app()->FillSmallBuffer(drawDataBuffer.get(), commands, sizeof(commands), 0,
+                           initialization_buffer,
+                           VK_ACCESS_INDIRECT_COMMAND_READ_BIT);
+
+    app()->FillSmallBuffer(countDataBuffer.get(), &num_commands,
+                           sizeof(num_commands), 0, initialization_buffer,
+                           VK_ACCESS_INDIRECT_COMMAND_READ_BIT);
   }
 
   virtual void InitializeFrameData(
-      DrawIndexedIndirectCountData* frame_data, vulkan::VkCommandBuffer* initialization_buffer,
+      DrawIndexedIndirectCountData* frame_data,
+      vulkan::VkCommandBuffer* initialization_buffer,
       size_t frame_index) override {
     frame_data->command_buffer_ =
         containers::make_unique<vulkan::VkCommandBuffer>(
@@ -271,8 +267,9 @@ class DrawIndexedIndirectCountSample : public sample_application::Sample<DrawInd
         &frame_data->cube_descriptor_set_->raw_set(), 0, nullptr);
     cube_.BindVertexAndIndexBuffers(&cmdBuffer);
 
-    cmdBuffer->vkCmdDrawIndexedIndirectCountKHR(cmdBuffer, 
-        *drawDataBuffer, 0, *countDataBuffer, 0, 10, static_cast<uint32_t>(sizeof(VkDrawIndexedIndirectCommand)));
+    cmdBuffer->vkCmdDrawIndexedIndirectCountKHR(
+        cmdBuffer, *drawDataBuffer, 0, *countDataBuffer, 0, 10,
+        static_cast<uint32_t>(sizeof(VkDrawIndexedIndirectCommand)));
 
     cmdBuffer->vkCmdEndRenderPass(cmdBuffer);
 

--- a/application_sandbox/khr_image_format_list/main.cpp
+++ b/application_sandbox/khr_image_format_list/main.cpp
@@ -59,45 +59,39 @@ class ImageFormatListSample
  public:
   ImageFormatListSample(const entry::EntryData* data)
       : data_(data),
-        Sample<ImageFormatListFrameData>(data->allocator(), data, 1, 512, 1, 1,
-                                      sample_application::SampleOptions(), {}, {"VK_KHR_image_format_list"}),
+        Sample<ImageFormatListFrameData>(
+            data->allocator(), data, 1, 512, 1, 1,
+            sample_application::SampleOptions(), {},
+            {VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME}),
         cube_(data->allocator(), data->logger(), cube_data),
         texture_(data->allocator(), data->logger(), texture_data) {}
   virtual void InitializeApplicationData(
       vulkan::VkCommandBuffer* initialization_buffer,
       size_t num_swapchain_images) override {
-
     VkFormat formats[] = {VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_SRGB};
     VkImageFormatListCreateInfoKHR image_format_pNext = {
-        VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR,
-        nullptr,
-        2,
-        formats
-    };
+        VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR, nullptr, 2,
+        formats};
     cube_.InitializeData(app(), initialization_buffer);
-    texture_.InitializeData(app(),
-        initialization_buffer,
-        VK_IMAGE_USAGE_SAMPLED_BIT,
-        VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT,
-        &image_format_pNext
-    );
+    texture_.InitializeData(
+        app(), initialization_buffer, VK_IMAGE_USAGE_SAMPLED_BIT,
+        VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, &image_format_pNext);
 
     VkImageViewCreateInfo view_create_info = {
-            VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
-            nullptr,                                   // pNext
-            0,                                         // flags
-            texture_.image(),                         // image
-            VK_IMAGE_VIEW_TYPE_2D,                     // viewType
-            VK_FORMAT_R8G8B8A8_SRGB,                   // format
-            {  VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B,
-            VK_COMPONENT_SWIZZLE_A},
-            {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}};
+        VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
+        nullptr,                                   // pNext
+        0,                                         // flags
+        texture_.image(),                          // image
+        VK_IMAGE_VIEW_TYPE_2D,                     // viewType
+        VK_FORMAT_R8G8B8A8_SRGB,                   // format
+        {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B,
+         VK_COMPONENT_SWIZZLE_A},
+        {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}};
 
     ::VkImageView raw_view;
-    LOG_ASSERT(
-        ==, data_->logger(), VK_SUCCESS,
-        app()->device()->vkCreateImageView(
-            app()->device(), &view_create_info, nullptr, &raw_view));
+    LOG_ASSERT(==, data_->logger(), VK_SUCCESS,
+               app()->device()->vkCreateImageView(
+                   app()->device(), &view_create_info, nullptr, &raw_view));
     mutable_image_view_ = containers::make_unique<vulkan::VkImageView>(
         data_->allocator(),
         vulkan::VkImageView(raw_view, nullptr, &app()->device()));
@@ -147,8 +141,7 @@ class ImageFormatListSample
         data_->allocator(),
         app()->CreatePipelineLayout(
             {{cube_descriptor_set_layouts_[0], cube_descriptor_set_layouts_[1],
-              cube_descriptor_set_layouts_[2],
-              cube_descriptor_set_layouts_[3],
+              cube_descriptor_set_layouts_[2], cube_descriptor_set_layouts_[3],
               cube_descriptor_set_layouts_[4]}}));
 
     VkAttachmentReference color_attachment = {
@@ -184,9 +177,8 @@ class ImageFormatListSample
             ));
 
     cube_pipeline_ = containers::make_unique<vulkan::VulkanGraphicsPipeline>(
-        data_->allocator(),
-        app()->CreateGraphicsPipeline(pipeline_layout_.get(),
-                                      render_pass_.get(), 0));
+        data_->allocator(), app()->CreateGraphicsPipeline(
+                                pipeline_layout_.get(), render_pass_.get(), 0));
     cube_pipeline_->AddShader(VK_SHADER_STAGE_VERTEX_BIT, "main",
                               image_format_list_vertex_shader);
     cube_pipeline_->AddShader(VK_SHADER_STAGE_FRAGMENT_BIT, "main",
@@ -229,14 +221,14 @@ class ImageFormatListSample
         containers::make_unique<vulkan::VkCommandBuffer>(
             data_->allocator(), app()->GetCommandBuffer());
 
-    frame_data
-        ->cube_descriptor_set_ = containers::make_unique<vulkan::DescriptorSet>(
-        data_->allocator(),
-        app()->AllocateDescriptorSet({
-            cube_descriptor_set_layouts_[0], cube_descriptor_set_layouts_[1],
-            cube_descriptor_set_layouts_[2], cube_descriptor_set_layouts_[3],
-            cube_descriptor_set_layouts_[4]
-        }));
+    frame_data->cube_descriptor_set_ =
+        containers::make_unique<vulkan::DescriptorSet>(
+            data_->allocator(),
+            app()->AllocateDescriptorSet({cube_descriptor_set_layouts_[0],
+                                          cube_descriptor_set_layouts_[1],
+                                          cube_descriptor_set_layouts_[2],
+                                          cube_descriptor_set_layouts_[3],
+                                          cube_descriptor_set_layouts_[4]}));
 
     VkDescriptorBufferInfo buffer_infos[2] = {
         {
@@ -255,16 +247,17 @@ class ImageFormatListSample
         VK_NULL_HANDLE,            // imageView
         VK_IMAGE_LAYOUT_UNDEFINED  //  imageLayout
     };
-    VkDescriptorImageInfo texture_info[2] = {{
-        VK_NULL_HANDLE,                            // sampler
-        texture_.view(),                           // imageView
-        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,  // imageLayout
-    },
-    {
-        VK_NULL_HANDLE,                            // sampler
-        *mutable_image_view_,                       // imageView
-        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,  // imageLayout
-    }};
+    VkDescriptorImageInfo texture_info[2] = {
+        {
+            VK_NULL_HANDLE,                            // sampler
+            texture_.view(),                           // imageView
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,  // imageLayout
+        },
+        {
+            VK_NULL_HANDLE,                            // sampler
+            *mutable_image_view_,                      // imageView
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,  // imageLayout
+        }};
 
     VkWriteDescriptorSet writes[3] = {
         {
@@ -299,7 +292,7 @@ class ImageFormatListSample
             0,                                       // dstArrayElement
             2,                                       // descriptorCount
             VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,        // descriptorType
-            texture_info,                           // pImageInfo
+            texture_info,                            // pImageInfo
             nullptr,                                 // pBufferInfo
             nullptr,                                 // pTexelBufferView
         },

--- a/application_sandbox/multigpu_particles/main.cpp
+++ b/application_sandbox/multigpu_particles/main.cpp
@@ -96,10 +96,11 @@ const VkCommandBufferBeginInfo kBeginCommandBufferOn0 = {
 int main_entry(const entry::EntryData* data) {
   auto* allocator = data->allocator();
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication app(
-      data->allocator(), data->logger(), data, {}, VkPhysicalDeviceFeatures{},
-      1024 * 1024 * 256, 1024 * 1024 * 256, 1024 * 1024 * 512,
-      1024 * 1024 * 256, false, false, true, 1024 * 1024 * 256);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {}, {},
+                                VkPhysicalDeviceFeatures{}, 1024 * 1024 * 256,
+                                1024 * 1024 * 256, 1024 * 1024 * 512,
+                                1024 * 1024 * 256, false, false, true,
+                                1024 * 1024 * 256);
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
   vulkan::VkQueue& render_queue = app.render_queue();

--- a/application_sandbox/render_3d_image/main.cpp
+++ b/application_sandbox/render_3d_image/main.cpp
@@ -64,7 +64,7 @@ class CopyImage2D3DSample
             128,  // Larger device buffer space may be required
             // if the swapchain image is large
             1, sample_application::SampleOptions(), VkPhysicalDeviceFeatures{},
-            {"VK_KHR_maintenance1"}),
+            {}, {VK_KHR_MAINTENANCE1_EXTENSION_NAME}),
         cube_(data->allocator(), data->logger(), cube_data) {}
   virtual void InitializeApplicationData(
       vulkan::VkCommandBuffer* initialization_buffer,

--- a/application_sandbox/sample_application_framework/sample_application.h
+++ b/application_sandbox/sample_application_framework/sample_application.h
@@ -130,11 +130,13 @@ class Sample {
          uint32_t device_buffer_size_in_MB, uint32_t coherent_buffer_size_in_MB,
          const SampleOptions& options,
          const VkPhysicalDeviceFeatures& physical_device_features = {0},
-         const std::initializer_list<const char*> extensions = {})
+         const std::initializer_list<const char*> instance_extensions = {},
+         const std::initializer_list<const char*> device_extensions = {})
       : options_(options),
         data_(entry_data),
         allocator_(allocator),
-        application_(allocator, entry_data->logger(), entry_data, extensions,
+        application_(allocator, entry_data->logger(), entry_data,
+                     device_extensions, instance_extensions,
                      physical_device_features,
                      host_buffer_size_in_MB * 1024 * 1024,
                      image_memory_size_in_MB * 1024 * 1024,

--- a/gapid_tests/command_buffer_tests/BufferImageCopy_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/BufferImageCopy_test/main.cpp
@@ -19,8 +19,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data, {}, {0}, 1024 * 100, 1024 * 100,
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        {}, {}, {0}, 1024 * 100, 1024 * 100,
                                         1024 * 100);
   VkImageCreateInfo image_create_info{
       /* sType = */ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,

--- a/gapid_tests/command_buffer_tests/SetDepthBias_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/SetDepthBias_test/main.cpp
@@ -93,7 +93,7 @@ void CreatePipelineAndSetDepthBias(const entry::EntryData* data,
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   vulkan::VulkanGraphicsPipeline pipeline =
       app.CreateGraphicsPipeline(&pipeline_layout, &render_pass, 0);
@@ -133,8 +133,9 @@ int main_entry(const entry::EntryData* data) {
 
   {
     const float depth_bias_constant_factor = 1.1f;
-    const float depth_bias_clamp = 0.0f;  // only 0.0 is valid as depthBiasClamp
-                                         // has not been confirmed as supported.
+    const float depth_bias_clamp =
+        0.0f;  // only 0.0 is valid as depthBiasClamp
+               // has not been confirmed as supported.
     const float depth_bias_slope_factor = 3.3f;
     // 1. Test with depthBiasClamp set to zero, so physical device feature:
     // depthBiasClamp is not required.
@@ -151,7 +152,7 @@ int main_entry(const entry::EntryData* data) {
     const float depth_bias_slope_factor = 3.3f;
     VkPhysicalDeviceFeatures request_features = {0};
     request_features.depthBiasClamp = VK_TRUE;
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
                                   {}, request_features);
     if (app.device().is_valid()) {
       CreatePipelineAndSetDepthBias(data, &app, depth_bias_constant_factor,

--- a/gapid_tests/command_buffer_tests/SetLineWidthAndBlendConstants_test/wide_lines.cpp
+++ b/gapid_tests/command_buffer_tests/SetLineWidthAndBlendConstants_test/wide_lines.cpp
@@ -96,7 +96,7 @@ vulkan::VulkanGraphicsPipeline CreateAndCommitPipeline(
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   vulkan::VulkanGraphicsPipeline pipeline =
       app.CreateGraphicsPipeline(&pipeline_layout, &render_pass, 0);
@@ -125,7 +125,7 @@ int main_entry(const entry::EntryData* data) {
     const float line_width = 2.0;
     VkPhysicalDeviceFeatures requested_feateures{};
     requested_feateures.wideLines = VK_TRUE;
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
                                   {}, requested_feateures);
     if (app.device().is_valid()) {
       // Create a pipeline

--- a/gapid_tests/command_buffer_tests/vkCmdBlitImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdBlitImage_test/main.cpp
@@ -24,8 +24,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data, {}, {0}, 1024 * 100, 1024 * 100,
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        {}, {}, {0}, 1024 * 100, 1024 * 100,
                                         1024 * 100);
 
   VkExtent3D src_image_extent{32, 32, 1};
@@ -52,8 +52,7 @@ int main_entry(const entry::EntryData* data) {
       application.CreateAndBindImage(&image_create_info);
   size_t image_data_size = vulkan::GetImageExtentSizeInBytes(
       src_image_extent, VK_FORMAT_R8G8B8A8_UNORM);
-  containers::vector<uint8_t> image_data(image_data_size, 0,
-                                         data->allocator());
+  containers::vector<uint8_t> image_data(image_data_size, 0, data->allocator());
   for (size_t i = 0; i < image_data_size; i++) {
     image_data[i] = i & 0xFF;
   }
@@ -99,7 +98,7 @@ int main_entry(const entry::EntryData* data) {
           {},                                     // wait_semaphores
           {image_fill_semaphore},                 // signal_semaphores
           static_cast<::VkFence>(VK_NULL_HANDLE)  // fence
-          );
+      );
   bool fill_succeed = std::get<0>(fill_result);
   // Before the all the image filling commands are executed, the command buffer
   // must not be freed.
@@ -205,7 +204,7 @@ int main_entry(const entry::EntryData* data) {
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,  // initial layout
         &dump_data,                            // data
         {}                                     // wait_semaphores
-        );
+    );
     LOG_ASSERT(==, data->logger(), image_data.size(), dump_data.size());
     LOG_ASSERT(
         ==, data->logger(), true,

--- a/gapid_tests/command_buffer_tests/vkCmdCopyImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdCopyImage_test/main.cpp
@@ -58,8 +58,8 @@ int main_entry(const entry::EntryData* data) {
     // miplevel and 0 offsets in all dimensions to another 2D image created
     // with same create info.
     vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                          data, {}, {0}, 1024 * 100, 1024 * 100,
-                                          1024 * 100);
+                                          data, {}, {}, {0}, 1024 * 100,
+                                          1024 * 100, 1024 * 100);
     vulkan::VkDevice& device = application.device();
 
     vulkan::ImagePointer src_image =
@@ -97,7 +97,7 @@ int main_entry(const entry::EntryData* data) {
             {},                                     // wait_semaphores
             {image_fill_semaphore},                 // signal_semaphores
             static_cast<::VkFence>(VK_NULL_HANDLE)  // fence
-            );
+        );
     bool fill_succeeded = std::get<0>(fill_result);
     // Before the all the image filling commands are executed, the command
     // buffer must not be freed.
@@ -145,7 +145,7 @@ int main_entry(const entry::EntryData* data) {
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,  // dstImageLayout
         1,                                     // regionCount
         &region                                // pRegions
-        );
+    );
     copy_image_cmd_buf->vkEndCommandBuffer(copy_image_cmd_buf);
 
     // Submit the commands
@@ -175,7 +175,7 @@ int main_entry(const entry::EntryData* data) {
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,  // initial layout
         &dump_data,                            // data
         {}                                     // wait_semaphores
-        );
+    );
     LOG_ASSERT(==, data->logger(), sample_image_data.size(), dump_data.size());
     LOG_ASSERT(==, data->logger(), true,
                std::equal(sample_image_data.begin(), sample_image_data.end(),
@@ -189,7 +189,7 @@ int main_entry(const entry::EntryData* data) {
     VkPhysicalDeviceFeatures requested_features = {0};
     requested_features.textureCompressionBC = VK_TRUE;
     vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                          data, {}, requested_features,
+                                          data, {}, {}, requested_features,
                                           1024 * 100, 1024 * 100, 1024 * 100);
     vulkan::VkDevice& device = application.device();
     if (device.is_valid()) {
@@ -244,7 +244,7 @@ int main_entry(const entry::EntryData* data) {
               {},                                     // wait_semaphores
               {image_fill_semaphore},                 // signal_semaphores
               static_cast<::VkFence>(VK_NULL_HANDLE)  // fence
-              );
+          );
       bool fill_succeeded = std::get<0>(fill_result);
       // Before the all the image filling commands are executed, the command
       // buffer must not be freed.
@@ -293,7 +293,7 @@ int main_entry(const entry::EntryData* data) {
           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,  // dstImageLayout
           1,                                     // regionCount
           &region                                // pRegions
-          );
+      );
       copy_image_cmd_buf->vkEndCommandBuffer(copy_image_cmd_buf);
 
       // Submit the commands
@@ -323,7 +323,7 @@ int main_entry(const entry::EntryData* data) {
           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,  // initial layout
           &dump_data,                            // data
           {}                                     // wait_semaphores
-          );
+      );
       LOG_ASSERT(==, data->logger(), copy_image_data.size(), dump_data.size());
       LOG_ASSERT(==, data->logger(), true,
                  std::equal(copy_image_data.begin(), copy_image_data.end(),

--- a/gapid_tests/command_buffer_tests/vkCmdNextSubpass_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdNextSubpass_test/main.cpp
@@ -63,8 +63,10 @@ const vulkan::VulkanGraphicsPipeline::InputStream kUVStream{
 };
 
 const VkCommandBufferBeginInfo kCommandBufferBeginInfo{
-    VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
-    VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, nullptr,
+    VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+    nullptr,
+    VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+    nullptr,
 };
 
 const VkSampleCountFlagBits kSampleCountBit = VK_SAMPLE_COUNT_1_BIT;
@@ -96,8 +98,8 @@ void EnqueueImageLayoutTransition(
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
-                                {}, 1024 * 128, 1024 * 1024 * 1024);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {}, {},
+                                {}, {}, 1024 * 128, 1024 * 1024 * 1024);
   vulkan::VkDevice& device = app.device();
 
   auto fence = vulkan::CreateFence(&app.device(), false);
@@ -196,7 +198,7 @@ int main_entry(const entry::EntryData* data) {
               0,                                              // flags
           },
       }  // SubpassDependencies
-      );
+  );
 
   // Create pipeline for the first subpass
   vulkan::PipelineLayout first_subpass_pipeline_layout(
@@ -292,9 +294,10 @@ int main_entry(const entry::EntryData* data) {
       },
   };
   ::VkImageView raw_swapchain_image_view;
-  LOG_ASSERT(==, data->logger(), app.device()->vkCreateImageView(
-                                app.device(), &swapchain_image_view_create_info,
-                                nullptr, &raw_swapchain_image_view),
+  LOG_ASSERT(==, data->logger(),
+             app.device()->vkCreateImageView(
+                 app.device(), &swapchain_image_view_create_info, nullptr,
+                 &raw_swapchain_image_view),
              VK_SUCCESS);
   vulkan::VkImageView swapchain_image_view(raw_swapchain_image_view, nullptr,
                                            &app.device());
@@ -415,7 +418,8 @@ int main_entry(const entry::EntryData* data) {
 
   cmd_buf->vkCmdEndRenderPass(cmd_buf);
 
-  app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf, &app.render_queue());
+  app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf,
+                                                   &app.render_queue());
 
   VkPresentInfoKHR present_info{
       VK_STRUCTURE_TYPE_PRESENT_INFO_KHR, nullptr,      0,      nullptr, 1,

--- a/gapid_tests/command_buffer_tests/vkCmdResolveImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdResolveImage_test/main.cpp
@@ -23,8 +23,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data, {}, {0}, 1024 * 100, 1024 * 100,
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        {}, {}, {0}, 1024 * 100, 1024 * 100,
                                         1024 * 100);
 
   const VkExtent3D sample_image_extent{32, 32, 1};
@@ -73,20 +73,21 @@ int main_entry(const entry::EntryData* data) {
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr, 0, nullptr};
     cmd_buf->vkBeginCommandBuffer(cmd_buf, &cmd_buf_begin_info);
     vulkan::RecordImageLayoutTransition(*src_image, clear_color_range,
-        VK_IMAGE_LAYOUT_UNDEFINED, 0, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        VK_ACCESS_TRANSFER_WRITE_BIT, &cmd_buf);
+                                        VK_IMAGE_LAYOUT_UNDEFINED, 0,
+                                        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                        VK_ACCESS_TRANSFER_WRITE_BIT, &cmd_buf);
     cmd_buf->vkCmdClearColorImage(cmd_buf, *src_image,
                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                   &clear_color, 1, &clear_color_range);
     // Switch src image layout from TRANSFER_DST to TRANSFER_SRC
-    vulkan::RecordImageLayoutTransition(*src_image, clear_color_range,
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT,
-        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_ACCESS_TRANSFER_READ_BIT,
-        &cmd_buf);
+    vulkan::RecordImageLayoutTransition(
+        *src_image, clear_color_range, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        VK_ACCESS_TRANSFER_WRITE_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        VK_ACCESS_TRANSFER_READ_BIT, &cmd_buf);
     vulkan::RecordImageLayoutTransition(*dst_image, clear_color_range,
-        VK_IMAGE_LAYOUT_UNDEFINED, 0,
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT,
-        &cmd_buf);
+                                        VK_IMAGE_LAYOUT_UNDEFINED, 0,
+                                        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                        VK_ACCESS_TRANSFER_WRITE_BIT, &cmd_buf);
     VkImageResolve image_resolve{
         // mip level 0, layerbase 0, layer count 1
         {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
@@ -124,7 +125,7 @@ int main_entry(const entry::EntryData* data) {
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,  // initial layout
         &dump_data,                            // data
         {}                                     // wait_semaphores
-        );
+    );
     containers::vector<uint8_t> expected_data(32 * 32 * 4, 0.5 * 255,
                                               data->allocator());
     LOG_ASSERT(==, data->logger(), expected_data.size(), dump_data.size());

--- a/gapid_tests/command_buffer_tests/vkCmdSetDepthBounds_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdSetDepthBounds_test/main.cpp
@@ -90,7 +90,7 @@ vulkan::VulkanGraphicsPipeline CreatePipelineWithDepthBoundTestEnabled(
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   vulkan::VulkanGraphicsPipeline pipeline =
       app.CreateGraphicsPipeline(&pipeline_layout, &render_pass, 0);
@@ -121,7 +121,7 @@ int main_entry(const entry::EntryData* data) {
     VkPhysicalDeviceFeatures request_features = {0};
     request_features.depthBounds = VK_TRUE;
 
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
                                   {}, request_features);
     if (app.device().is_valid()) {
       auto pipeline = CreatePipelineWithDepthBoundTestEnabled(data, &app);

--- a/gapid_tests/command_buffer_tests/vkCmdUpdateBuffer_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdUpdateBuffer_test/main.cpp
@@ -22,8 +22,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data, {}, {0}, 1024 * 100, 1024 * 100,
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        {}, {}, {0}, 1024 * 100, 1024 * 100,
                                         1024 * 100);
   {
     // Update a buffer with size 65536 bytes and 0 offset.
@@ -55,7 +55,7 @@ int main_entry(const entry::EntryData* data) {
                                0,                  // dstOffset
                                update_size,        // dataSize
                                buffer_data.data()  // pData
-                               );
+    );
 
     VkBufferMemoryBarrier dst_to_src_barrier{
         VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,  // sType
@@ -79,7 +79,7 @@ int main_entry(const entry::EntryData* data) {
         &dst_to_src_barrier,             // pBufferMemoryBarriers
         0,                               // imageMemoryBarrierCount
         nullptr                          // pImageMemoryBarriers
-        );
+    );
 
     cmd_buf->vkEndCommandBuffer(cmd_buf);
     VkCommandBuffer raw_cmd_buf = cmd_buf.get_command_buffer();

--- a/gapid_tests/extension_tests/VK_NV_dedicated_allocation_test/main.cpp
+++ b/gapid_tests/extension_tests/VK_NV_dedicated_allocation_test/main.cpp
@@ -22,11 +22,12 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
                                 {VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME});
   vulkan::VkDevice& device = app.device();
   if (device.is_valid()) {
-    data->logger()->LogInfo(VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME, " found.");
+    data->logger()->LogInfo(VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME,
+                            " found.");
 
     {  // 1. Image Test
       VkDedicatedAllocationImageCreateInfoNV dedicated_image_info = {
@@ -126,7 +127,7 @@ int main_entry(const entry::EntryData* data) {
     }
   } else {
     data->logger()->LogInfo("Disabled test due to missing ",
-                       VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME);
+                            VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME);
   }
   data->logger()->LogInfo("Application Shutdown");
   return 0;

--- a/gapid_tests/extension_tests/VK_NV_dedicated_allocation_test/main_no_dedicated.cpp
+++ b/gapid_tests/extension_tests/VK_NV_dedicated_allocation_test/main_no_dedicated.cpp
@@ -22,11 +22,12 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
                                 {VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME});
   vulkan::VkDevice& device = app.device();
   if (device.is_valid()) {
-    data->logger()->LogInfo(VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME, " found.");
+    data->logger()->LogInfo(VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME,
+                            " found.");
 
     {  // 1. Image Test
       VkDedicatedAllocationImageCreateInfoNV dedicated_image_info = {
@@ -77,7 +78,7 @@ int main_entry(const entry::EntryData* data) {
       VkDedicatedAllocationBufferCreateInfoNV dedicated_buffer_info = {
           VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV,  // sType
           nullptr,  // pNext
-          VK_FALSE   // dedicatedAllocation
+          VK_FALSE  // dedicatedAllocation
       };
 
       VkBufferCreateInfo buffer_create_info = {
@@ -116,7 +117,7 @@ int main_entry(const entry::EntryData* data) {
     }
   } else {
     data->logger()->LogInfo("Disabled test due to missing ",
-                       VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME);
+                            VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME);
   }
   data->logger()->LogInfo("Application Shutdown");
   return 0;

--- a/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/pipeline_statistic.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/pipeline_statistic.cpp
@@ -32,7 +32,7 @@ int main_entry(const entry::EntryData* data) {
     VkPhysicalDeviceFeatures request_features = {0};
     request_features.pipelineStatisticsQuery = VK_TRUE;
     vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                          data, {}, request_features);
+                                          data, {}, {}, request_features);
     if (application.device().is_valid()) {
       vulkan::VkDevice& device = application.device();
       VkQueryPoolCreateInfo query_pool_create_info = {

--- a/gapid_tests/resource_creation_tests/CreateDestroySampler_test/unnormalized.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroySampler_test/unnormalized.cpp
@@ -30,7 +30,7 @@ int main_entry(const entry::EntryData* data) {
   {  // Sampler using unnormalized coordinates
     VkPhysicalDeviceFeatures requested_features = {0};
     requested_features.samplerAnisotropy = VK_TRUE;
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
                                   {}, requested_features);
     if (app.device().is_valid()) {
       vulkan::VkDevice& device = app.device();

--- a/vulkan_helpers/helper_functions.h
+++ b/vulkan_helpers/helper_functions.h
@@ -54,16 +54,18 @@ VkInstance CreateDefaultInstance(containers::Allocator* allocator,
 // Creates an instance with either a real or virtual swapchain based on
 // whether or not data requests an external swapchain. Otherwise
 // identical to CreateDefaultInstance.
-VkInstance CreateInstanceForApplication(containers::Allocator* allocator,
-                                        LibraryWrapper* wrapper,
-                                        const entry::EntryData* data);
+VkInstance CreateInstanceForApplication(
+    containers::Allocator* allocator, LibraryWrapper* wrapper,
+    const entry::EntryData* data,
+    const std::initializer_list<const char*> extensions);
 
 // Creates an instance with either a real or virtual swapchain based on
 // whether or not data requests an external swapchain. Otherwise
 // identical to CreateDefaultInstance.
-VkInstance Create11InstanceForApplication(containers::Allocator* allocator,
-                                          LibraryWrapper* wrapper,
-                                          const entry::EntryData* data);
+VkInstance Create11InstanceForApplication(
+    containers::Allocator* allocator, LibraryWrapper* wrapper,
+    const entry::EntryData* data,
+    const std::initializer_list<const char*> extensions);
 
 containers::vector<VkPhysicalDevice> GetPhysicalDevices(
     containers::Allocator* allocator, VkInstance& instance);

--- a/vulkan_helpers/vulkan_application.h
+++ b/vulkan_helpers/vulkan_application.h
@@ -424,18 +424,18 @@ class VulkanApplication {
   //  One for host-visible buffers.
   //  One for device-only-accessible buffers.
   //  One for device-only images.
-  VulkanApplication(containers::Allocator* allocator, logging::Logger* log,
-                    const entry::EntryData* entry_data,
-                    const std::initializer_list<const char*> extensions = {},
-                    const VkPhysicalDeviceFeatures& features = {0},
-                    uint32_t host_buffer_size = 1024 * 128,
-                    uint32_t device_image_size = 1024 * 128,
-                    uint32_t device_buffer_size = 1024 * 128,
-                    uint32_t coherent_buffer_size = 1024 * 128,
-                    bool use_async_compute_queue = false,
-                    bool use_sparse_binding = false,
-                    bool use_device_groups = false,
-                    uint32_t device_peer_memory_size = 0);
+  VulkanApplication(
+      containers::Allocator* allocator, logging::Logger* log,
+      const entry::EntryData* entry_data,
+      const std::initializer_list<const char*> instance_extensions = {},
+      const std::initializer_list<const char*> device_extensions = {},
+      const VkPhysicalDeviceFeatures& features = {0},
+      uint32_t host_buffer_size = 1024 * 128,
+      uint32_t device_image_size = 1024 * 128,
+      uint32_t device_buffer_size = 1024 * 128,
+      uint32_t coherent_buffer_size = 1024 * 128,
+      bool use_async_compute_queue = false, bool use_sparse_binding = false,
+      bool use_device_groups = false, uint32_t device_peer_memory_size = 0);
 
   // Creates an image from the given create_info, and binds memory from the
   // device-only image Arena.
@@ -804,8 +804,7 @@ class VulkanApplication {
   VkSwapchainKHR swapchain_;
   VkCommandPool command_pool_;
   VkPipelineCache pipeline_cache_;
-  containers::vector<
-      containers::unique_ptr<VulkanArena>> host_accessible_heap_;
+  containers::vector<containers::unique_ptr<VulkanArena>> host_accessible_heap_;
   containers::vector<containers::unique_ptr<VulkanArena>> coherent_heap_;
   containers::unique_ptr<VulkanArena> device_only_image_heap_;
   containers::unique_ptr<VulkanArena> device_only_buffer_heap_;


### PR DESCRIPTION
Instance extension list comes before the device extensions in
constructors and functions when both are specified.

Also changes all direct text extensions ("VK_KHR_draw_indirect_count")
to use the standard #define (VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)
for future grepping.

Clang format also rearranged some random code here and there.