### PR TITLE
Added optional load/save pipeline cache functionality to Applications.

### DIFF
--- a/application_sandbox/sample_application_framework/sample_application.h
+++ b/application_sandbox/sample_application_framework/sample_application.h
@@ -302,6 +302,7 @@ class Sample {
           application_.render_queue(), 0, nullptr, *frame_data.ready_fence_);
     }
 
+    application_.InitializationComplete();
     InitializationComplete();
     data_->NotifyReady();
   }

--- a/support/entry/entry.h
+++ b/support/entry/entry.h
@@ -69,7 +69,9 @@ class EntryData {
   EntryData(containers::Allocator* allocator, uint32_t width, uint32_t height,
             bool fixed_timestep, bool separate_present,
             int64_t output_frame_index, const char* output_frame_file,
-            const char* shader_compiler, bool validation
+            const char* shader_compiler, bool validation,
+            const char* load_pipeline_cache,
+            const char* write_pipeline_cache
 #if defined __ANDROID__
             ,
             android_app* app
@@ -130,6 +132,12 @@ class EntryData {
   const char* output_frame_file() const { return output_frame_file_; }
   const char* shader_compiler() const { return shader_compiler_; }
   bool validation() const { return validation_; }
+  const char* load_pipeline_cache() const { 
+    return load_pipeline_cache_.empty()? nullptr: load_pipeline_cache_.c_str();
+  }
+  const char* write_pipeline_cache() const {
+    return write_pipeline_cache_.empty()? nullptr: write_pipeline_cache_.c_str();
+  }
 
  private:
   bool fixed_timestep_;
@@ -142,6 +150,8 @@ class EntryData {
   const bool validation_;
   containers::unique_ptr<logging::Logger> log_;
   containers::Allocator* allocator_;
+  std::string load_pipeline_cache_;
+  std::string write_pipeline_cache_;
 
 #if defined __ANDROID__
   ANativeWindow* native_window_handle_;

--- a/vulkan_helpers/helper_functions.h
+++ b/vulkan_helpers/helper_functions.h
@@ -264,7 +264,12 @@ VkQueue inline GetQueue(VkDevice* device, uint32_t queue_family_index,
 }
 
 // Creates a default pipeline cache, it does not load anything from disk.
-VkPipelineCache CreateDefaultPipelineCache(VkDevice* device);
+VkPipelineCache CreateDefaultPipelineCache(VkDevice* device,
+    const entry::EntryData* entry_data);
+
+// Writes the given pipeline cache to the given file.
+void WritePipelineCache(VkDevice* device, VkPipelineCache* cache,
+    const char* location);
 
 // Creates a query pool with the given query pool create info from the given
 // device if the given device is valid. Otherwise returns a query pool with

--- a/vulkan_helpers/vulkan_application.cpp
+++ b/vulkan_helpers/vulkan_application.cpp
@@ -101,7 +101,7 @@ VulkanApplication::VulkanApplication(
               : 0,
           use_10bit_hdr, swapchain_extensions)),
       command_pools_(allocator_),
-      pipeline_cache_(CreateDefaultPipelineCache(&device_)),
+      pipeline_cache_(CreateDefaultPipelineCache(&device_, entry_data)),
       host_accessible_heap_(allocator_),
       coherent_heap_(allocator_),
       device_peer_memory_heaps_(allocator_),
@@ -448,6 +448,12 @@ VkDevice VulkanApplication::CreateDevice(
 
   return SetupDevice(std::move(device), create_async_compute_queue,
                      use_sparse_binding);
+}
+
+void VulkanApplication::InitializationComplete() {
+  if (entry_data_->write_pipeline_cache()) {
+    WritePipelineCache(&device_, &pipeline_cache_, entry_data_->write_pipeline_cache());
+  }
 }
 
 containers::unique_ptr<VulkanApplication::Image>

--- a/vulkan_helpers/vulkan_application.h
+++ b/vulkan_helpers/vulkan_application.h
@@ -769,6 +769,12 @@ class VulkanApplication {
                                   subpass_);
   }
 
+  // Call this when all initialization has been done, and applications
+  // are expected to be in their main loop. This will cause the
+  // VulkanApplication to write out its pipeline cache if
+  // requested on the command-line.
+  void InitializationComplete();
+
   // Creates a render pass, from the given VkAttachmentDescriptions2,
   // VkSubpassDescriptions2, and VkSubpassDependencies2
   VkRenderPass CreateRenderPass2(


### PR DESCRIPTION
This adds --load-pipeline-cache=<file> --write-pipeline-cache=<file>
that all sample applications will use to read/write pipeline caches.