### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/.build-android.dockerfile
+++ b/.build-android.dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu
 COPY . /root/vulkan_test_applications
 
 RUN apt-get update -qq && \
-apt-get install -qq -y git gcc g++ ninja-build python3 python3-pip cmake libxcb1-dev openjdk-8-jdk wget unzip && \
+apt-get --no-install-recommends install -qq -y git gcc g++ ninja-build python3 python3-pip cmake libxcb1-dev openjdk-8-jdk wget unzip && \
 pip3 install pillow
 
 WORKDIR /root

--- a/.build-linux.dockerfile
+++ b/.build-linux.dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu
 COPY . /root/vulkan_test_applications
 
 RUN apt-get update -qq && \
-apt-get install -qq -y git gcc g++ ninja-build python3 python3-pip cmake libxcb1-dev
+apt-get --no-install-recommends install -qq -y git gcc g++ ninja-build python3 python3-pip cmake libxcb1-dev
 
 RUN pip3 install pillow
 


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>