### PR TITLE
Fix validation error for samples using VK_KHR_multiview.

### DIFF
--- a/application_sandbox/create_renderpass2/main.cpp
+++ b/application_sandbox/create_renderpass2/main.cpp
@@ -91,7 +91,8 @@ class MixedSamplesSample
             data->allocator(), data, 1, 512, 1, 1,
             sample_application::SampleOptions().AddDeviceExtensionStructure(
                 (void*)&kMultiviewFeatures),
-            {0}, {},
+            {0},
+            {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME},
             {VK_KHR_MULTIVIEW_EXTENSION_NAME,
              VK_KHR_MAINTENANCE2_EXTENSION_NAME,
              VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME}),

--- a/application_sandbox/depth_stencil_resolve/main.cpp
+++ b/application_sandbox/depth_stencil_resolve/main.cpp
@@ -81,7 +81,8 @@ class MixedSamplesSample
       : data_(data),
         Sample<MixedSamplesFrameData>(
             data->allocator(), data, 1, 512, 1, 1,
-            sample_application::SampleOptions().EnableMultisampling(), {0}, {},
+            sample_application::SampleOptions().EnableMultisampling(), {0},
+            {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME},
             {VK_KHR_MULTIVIEW_EXTENSION_NAME,
              VK_KHR_MAINTENANCE2_EXTENSION_NAME,
              VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,


### PR DESCRIPTION
create_renderpass2 and depth_stencil_resolve weren't including
VK_KHR_get_physical_device_properties2 in their isntance extensions in
spite of it being required for VK_KHR_multiview (which they both use).
Fix this by adding get_physical_device_properties2 to their instance
extensions.