### PR TITLE
Remove storagePushConstant8 from apps that don't used it

### DIFF
--- a/application_sandbox/shader_float16_int8/main.cpp
+++ b/application_sandbox/shader_float16_int8/main.cpp
@@ -52,7 +52,7 @@ static VkPhysicalDevice8BitStorageFeaturesKHR eight_bit_storage_feature{
     &float_sixteen_int_eight_feature,  // pNext;
     true,     // storageBuffer8BitAccess;
     true,     // uniformAndStorageBuffer8BitAccess;
-    true      // storagePushConstant8;
+    false     // storagePushConstant8;
 };
 
 static void* device_extension_list = &eight_bit_storage_feature;

--- a/application_sandbox/storage_8bit/main.cpp
+++ b/application_sandbox/storage_8bit/main.cpp
@@ -44,7 +44,7 @@ static VkPhysicalDevice8BitStorageFeaturesKHR eight_bit_storage_feature{
     nullptr,  // pNext;
     true,     // storageBuffer8BitAccess;
     true,     // uniformAndStorageBuffer8BitAccess;
-    true      // storagePushConstant8;
+    false     // storagePushConstant8;
 };
 
 struct CubeFrameData {


### PR DESCRIPTION
The two applications being changed, shader_float16_int8 and storage_8bit, don't use storagePushConstant8 but request support when creating a device. This change allows these applications to work on platforms that have the required 8bit storage support but don't support storagePushConstant8.