### PR TITLE
Add Push Constants to CreatePipelineLayout

### DIFF
--- a/vulkan_helpers/vulkan_application.h
+++ b/vulkan_helpers/vulkan_application.h
@@ -723,8 +723,9 @@ class VulkanApplication {
   // DescriptorSetLayoutBindings
   PipelineLayout CreatePipelineLayout(
       std::initializer_list<DescriptorSetLayoutBinding>
-          layouts) {
-    return PipelineLayout(allocator_, &device_, layouts);
+          layouts,
+      std::initializer_list<VkPushConstantRange> ranges = {}) {
+    return PipelineLayout(allocator_, &device_, layouts, ranges);
   }
 
   // Allocates a descriptor set with one descriptor according to the given


### PR DESCRIPTION
Fixes a mistake with https://github.com/google/vulkan_test_applications/pull/172

Currently Push Constants cannot be used with vulkan::PipelineLayout because it can only be created via CreatePipelineLayout which doesn't support the optional parameter for VkPushConstantRanges.