### PR TITLE
Fix missing allocator in PipelineLayout constructor

### DIFF
--- a/vulkan_helpers/vulkan_application.h
+++ b/vulkan_helpers/vulkan_application.h
@@ -260,8 +260,8 @@ class PipelineLayout {
       raw_layouts.push_back(descriptor_set_layouts_.back());
     }
 
-    containers::vector<VkPushConstantRange> push_constant_ranges(ranges.begin(),
-                                                            ranges.end());
+    containers::vector<VkPushConstantRange> push_constant_ranges(
+        ranges.begin(), ranges.end(), allocator);
 
     VkPipelineLayoutCreateInfo create_info = {
         VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,  // sType


### PR DESCRIPTION
The PipelineLayout constructor uses a vector of VkPushConstantRange. However, it wasn't declared with the required allocator and the program crashes whenever push constants are used with CreatePipelineLayout.

This PR fixes the problem. 