### PR TITLE
Change pipeline barrier after copying buffer 

### DIFF
--- a/vulkan_helpers/buffer_frame_data.h
+++ b/vulkan_helpers/buffer_frame_data.h
@@ -126,6 +126,7 @@ class BufferFrameData {
 
       barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
       barrier.dstAccessMask = VK_ACCESS_UNIFORM_READ_BIT;
+      barrier.buffer = *buffer_;
       update_commands_.back()->vkCmdPipelineBarrier(
           update_commands_.back(), VK_PIPELINE_STAGE_TRANSFER_BIT,
           VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 1, &barrier, 0,


### PR DESCRIPTION
After vkCmdCopyBuffer the pipeline barrier from transfer write to
uniform read should be performed on the destination barrier. Previously
performed on the host barrier.