### PR TITLE
Conditional rendering patch

### DIFF
--- a/application_sandbox/conditional_rendering/cube.frag
+++ b/application_sandbox/conditional_rendering/cube.frag
@@ -18,14 +18,9 @@
 layout(location = 0) out vec4 out_color;
 layout(location = 1) in vec2 texcoord;
 
-layout(set = 0, binding = 2) uniform samplerBuffer alphaData;
+layout(set = 0, binding = 2) uniform samplerBuffer colorScale;
 
 void main() {
-    float a = texelFetch(alphaData, 0).r;
-    float b = a;
-    if (b > 1.0) {
-      b = 2.0 - b;
-    }
-    vec3 color = vec3(texcoord, 1.0) * b;
+    vec3 color = vec3(texcoord, 1.0) * texelFetch(colorScale, 0).r;
     out_color = vec4(color, 1.0);
 }

--- a/application_sandbox/conditional_rendering/main.cpp
+++ b/application_sandbox/conditional_rendering/main.cpp
@@ -344,11 +344,11 @@ class ConditionalRenderingSample
 
     // Two colorful cubes with a blue background
     VkConditionalRenderingBeginInfoEXT conditional_begin1 = {
-        VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT,
-        nullptr,
-        conditional_data_->get_buffer(),
-        conditional_data_->get_offset_for_frame(frame_index),
-        0,
+        VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT,  // sType
+        nullptr,                                                 // pNext
+        conditional_data_->get_buffer(),                         // buffer
+        conditional_data_->get_offset_for_frame(frame_index),    // offset
+        0,                                                       // flags
     };
 
     // Single black cube with a pink background
@@ -451,15 +451,20 @@ class ConditionalRenderingSample
 
     conditional_data_->data().condition =
         (frames_since_last_notify_ % 120) < 60;
-    dispatch_data_->data().value += 1.0;
+    // Reset alpha value to 0.
+    dispatch_data_->data().value = 0;
   }
+
   virtual void Render(vulkan::VkQueue* queue, size_t frame_index,
                       ConditionalRenderingFrameData* frame_data) override {
     // Update our uniform buffers.
     camera_data_->UpdateBuffer(queue, frame_index);
     model_data_->UpdateBuffer(queue, frame_index);
     conditional_data_->UpdateBuffer(queue, frame_index);
-    dispatch_data_->UpdateBuffer(queue, frame_index);
+    // Force update for the compute shader buffer, since it is
+    // updated by the GPU.
+    bool forceUpdate = true;
+    dispatch_data_->UpdateBuffer(queue, frame_index, 0, forceUpdate);
 
     VkSubmitInfo init_submit_info{
         VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType

--- a/vulkan_helpers/buffer_frame_data.h
+++ b/vulkan_helpers/buffer_frame_data.h
@@ -126,6 +126,9 @@ class BufferFrameData {
 
       barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
       barrier.dstAccessMask = VK_ACCESS_UNIFORM_READ_BIT;
+      if ((usage & VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT) != 0) {
+        barrier.dstAccessMask |= VK_ACCESS_CONDITIONAL_RENDERING_READ_BIT_EXT;
+      }
       barrier.buffer = *buffer_;
       update_commands_.back()->vkCmdPipelineBarrier(
           update_commands_.back(), VK_PIPELINE_STAGE_TRANSFER_BIT,

--- a/vulkan_helpers/buffer_frame_data.h
+++ b/vulkan_helpers/buffer_frame_data.h
@@ -126,6 +126,7 @@ class BufferFrameData {
 
       barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
       barrier.dstAccessMask = VK_ACCESS_UNIFORM_READ_BIT;
+      barrier.buffer = *buffer_;
       update_commands_.back()->vkCmdPipelineBarrier(
           update_commands_.back(), VK_PIPELINE_STAGE_TRANSFER_BIT,
           VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 1, &barrier, 0,


### PR DESCRIPTION
- Simplify fragment shader, value in colorScale should be 0 or 1
- Update dispatch buffer value to 0
- Force update dispatch buffer update. Since it's value is updated
by the GPU, values might not be up to date when UpdateBuffer does
a comparison to decide whether to update.
- Add proper dstAccessMask bits for conditional rendering buffer