### PR TITLE
Add a helper function to find a supported depth/stencil format.

### DIFF
--- a/application_sandbox/sample_application_framework/sample_application.h
+++ b/application_sandbox/sample_application_framework/sample_application.h
@@ -231,23 +231,9 @@ class Sample {
 
     depth_stencil_format_ = kDepthFormat;
     if (options_.enable_stencil) {
-      VkFormatProperties properties = {};
-      depth_stencil_format_ = VK_FORMAT_D32_SFLOAT_S8_UINT;
-      application_.instance()->vkGetPhysicalDeviceFormatProperties(
-          application_.device().physical_device(), depth_stencil_format_,
-          &properties);
-      if ((properties.optimalTilingFeatures &
-           VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-        // Check the other format instead.
-        depth_stencil_format_ = VK_FORMAT_D24_UNORM_S8_UINT;
-        application_.instance()->vkGetPhysicalDeviceFormatProperties(
-            application_.device().physical_device(), depth_stencil_format_,
-            &properties);
-        // Double check that this is supported.
-        LOG_ASSERT(!=, data_->logger(), 0,
-                   (properties.optimalTilingFeatures &
-                    VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT));
-      }
+      depth_stencil_format_ = GetSupportedDepthStencilFormat(
+          &application_.instance(), &application_.device());
+      LOG_ASSERT(!=, data_->logger(), VK_FORMAT_UNDEFINED, depth_stencil_format_);
     }
 
     num_samples_ = options.enable_multisampling ? kVkMultiSampledSampleCount


### PR DESCRIPTION
This adds a helper function, GetSupportedDepthStencilFormat, that can be used by any application. The sample application has been changed to make use of this.

Additionally, the stencil sample has been updated to make use of the built-in stencil support.