### PR TITLE
Fix async_compute submit after device wait idle

### DIFF
--- a/application_sandbox/async_compute/main.cpp
+++ b/application_sandbox/async_compute/main.cpp
@@ -395,10 +395,12 @@ class ASyncThreadRunner {
         ->vkQueueWaitIdle((*app_->async_compute_queue()));
   }
 
-  ~ASyncThreadRunner() {
+  void Shutdown() {
     exit_.store(true);
     runner_.join();
   }
+
+  ~ASyncThreadRunner() {}
 
   // There is only one time that index can be a value that was not
   // returned from this function before, and that is if this is the
@@ -693,6 +695,13 @@ class AsyncSample : public sample_application::Sample<AsyncFrameData> {
       app()->GetLogger()->LogError("Could not find async compute queue.");
       set_invalid(true);
     }
+  }
+
+  void WaitIdle() override {
+      if(should_exit() || data_->WindowClosing()) {
+          thread_runner_.Shutdown();
+      }
+      sample_application::Sample<AsyncFrameData>::WaitIdle();
   }
 
   virtual void InitializeApplicationData(

--- a/application_sandbox/sample_application_framework/sample_application.h
+++ b/application_sandbox/sample_application_framework/sample_application.h
@@ -320,7 +320,7 @@ class Sample {
     data_->NotifyReady();
   }
 
-  void WaitIdle() { app()->device()->vkDeviceWaitIdle(app()->device()); }
+  virtual void WaitIdle() { app()->device()->vkDeviceWaitIdle(app()->device()); }
 
   // The format that we are using to render. This will be either the swapchain
   // format if we are not rendering multi-sampled, or the multisampled image


### PR DESCRIPTION
In async_compute test application, async thread runner continues to
submit work after vkDeviceWaitIdle is resolved. This change fixes
this behaviour by terminating the async thread before wait idle.