### PR TITLE
Fix configure_files parameter, replacing COPY_ONLY with COPYONLY

### DIFF
--- a/support/android_native_app_glue/CMakeLists.txt
+++ b/support/android_native_app_glue/CMakeLists.txt
@@ -15,9 +15,9 @@
 
 if (ANDROID)
     configure_file(${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c
-        ${CMAKE_CURRENT_BINARY_DIR}/android_native_app_glue.c COPY_ONLY)
+        ${CMAKE_CURRENT_BINARY_DIR}/android_native_app_glue.c COPYONLY)
     configure_file(${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.h
-        ${CMAKE_CURRENT_BINARY_DIR}/android_native_app_glue.h COPY_ONLY)
+        ${CMAKE_CURRENT_BINARY_DIR}/android_native_app_glue.h COPYONLY)
 
     add_vulkan_static_library(
         android_native_app_glue SOURCES


### PR DESCRIPTION
From issue #210 , the usage of COPY_ONLY is incorrect in newer versions of cmake. This has been change to COPYONLY. I ran the two docker builds (linux and android) with this change and both build without issue.