### PR TITLE
Update action workflow due to recent python changes.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,7 @@ jobs:
     - uses: actions/checkout@v2
       with: 
         submodules: 'recursive'
+    - uses: actions/setup-python@v2
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
     - name: Setup External Tools
@@ -22,7 +23,7 @@ jobs:
     - name: Configure
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake -GNinja $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPYTHON_EXECUTABLE=/usr/bin/python3
+      run: cmake -GNinja $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash

--- a/cmake/build_apk.cmake
+++ b/cmake/build_apk.cmake
@@ -14,7 +14,8 @@
 #
 
 include(CMakeParseArguments)
-find_package(PythonInterp)
+find_package(Python3 COMPONENTS Interpreter)
+
 
 list(LENGTH CMAKE_CONFIGURATION_TYPES num_elements)
 if (num_elements GREATER 1)
@@ -135,7 +136,7 @@ function(compile_glsl_using_glslc shader output_file)
       ${VulkanTestApplications_SOURCE_DIR}/cmake/generate_cmake_dep.py
     COMMAND ${CMAKE_GLSL_COMPILER} -mfmt=c -o ${output_file} -c ${input_file} -MD
       ${ADDITIONAL_ARGS}
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${Python3_EXECUTABLE}
       ${VulkanTestApplications_SOURCE_DIR}/cmake/generate_cmake_dep.py
       ${output_file}.d
     COMMAND ${CMAKE_COMMAND} -E
@@ -157,7 +158,7 @@ function(compile_hlsl_using_glslc shader output_file result)
     DEPENDS ${shader} ${FILE_DEPS}
       ${VulkanTestApplications_SOURCE_DIR}/cmake/generate_cmake_dep.py
     COMMAND ${CMAKE_GLSL_COMPILER} -mfmt=c -x hlsl -o ${glslc_hlsl_filename} -c ${input_file} -MD
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${Python3_EXECUTABLE}
       ${VulkanTestApplications_SOURCE_DIR}/cmake/generate_cmake_dep.py
       ${glslc_hlsl_filename}.d
     COMMAND ${CMAKE_COMMAND} -E
@@ -190,7 +191,7 @@ function(compile_hlsl_using_dxc shader output_file result)
     COMMENT "Compiling HLSL to SPIR-V binary using DXC: ${shader}"
     DEPENDS ${shader} ${FILE_DEPS} ${VulkanTestApplications_SOURCE_DIR}/tools/spirv_c_mfmt.py
     COMMAND ${CMAKE_DXC_COMPILER} -spirv -Fo ${dxc_hlsl_filename} -E main -T ${DXC_TARGET_ENV} ${input_file}
-    COMMAND ${PYTHON_EXECUTABLE} ${VulkanTestApplications_SOURCE_DIR}/tools/spirv_c_mfmt.py ${dxc_hlsl_filename} --output-file=${dxc_hlsl_filename}
+    COMMAND ${Python3_EXECUTABLE} ${VulkanTestApplications_SOURCE_DIR}/tools/spirv_c_mfmt.py ${dxc_hlsl_filename} --output-file=${dxc_hlsl_filename}
   )
   endif()
   set(${result} ${dxc_hlsl_filename} PARENT_SCOPE)
@@ -436,7 +437,7 @@ function(add_model_library target)
         COMMENT "Compiling Model ${model}"
         DEPENDS ${model}
           ${VulkanTestApplications_SOURCE_DIR}/cmake/convert_obj_to_c.py
-        COMMAND ${PYTHON_EXECUTABLE}
+        COMMAND ${Python3_EXECUTABLE}
           ${VulkanTestApplications_SOURCE_DIR}/cmake/convert_obj_to_c.py
             ${model} -o ${output_file}
       )
@@ -558,7 +559,7 @@ function(add_texture_library target)
         COMMENT "Compiling texture ${texture}"
         DEPENDS ${texture}
           ${VulkanTestApplications_SOURCE_DIR}/cmake/convert_img_to_c.py
-        COMMAND ${PYTHON_EXECUTABLE}
+        COMMAND ${Python3_EXECUTABLE}
           ${VulkanTestApplications_SOURCE_DIR}/cmake/convert_img_to_c.py
             ${texture} -o ${output_file}
       )


### PR DESCRIPTION
Some recent change to the ubuntu-18.04 VM broke the python setup. This change fixes the build via the following:

* Add a `uses` to setup python, this seems to be the recommended way to get python installed.
* Changed the cmake process to find Python3 instead of the deprecated PythonInterp, this will now properly pick up the python install via the additional `uses`.