### PR TITLE
Add support for gracefully closing applications on Win32.

### DIFF
--- a/support/entry/entry.h
+++ b/support/entry/entry.h
@@ -113,6 +113,7 @@ class EntryData {
 #elif defined _WIN32
   HWND native_window_handle() const { return native_window_handle_; }
   HINSTANCE native_hinstance() const { return native_hinstance_; }
+  void CloseWindow() { window_closing_ = true; }
 #elif defined __ggp__
 // Empty
 #elif defined __linux__
@@ -160,6 +161,7 @@ class EntryData {
 #elif defined _WIN32
   HINSTANCE native_hinstance_;
   HWND native_window_handle_;
+  bool window_closing_;
 #elif defined __ggp__
 // Empty
 #elif defined __linux__


### PR DESCRIPTION
Closing the application on Win32 would lead to a crash due to a VK_ERROR_OUT_OF_DATE when doing a present. This PR adds support for properly shutting down to avoid the crash. This also allows for proper memory leak detection.

Additionally, some window style properties (resize, maximize) were removed to avoid other scenarios where an VK_ERROR_OUT_OF_DATE is generated.