### PR TITLE
Add support for specifying offset alignment in BufferFrameData.

### DIFF
--- a/application_sandbox/async_compute/main.cpp
+++ b/application_sandbox/async_compute/main.cpp
@@ -106,7 +106,8 @@ class ASyncThreadRunner {
 
     update_time_data_ = containers::make_unique<vulkan::BufferFrameData<Mat44>>(
         allocator_, app_, num_async_compute_buffers,
-        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, 0, app_->async_compute_queue()->index());
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, 
+        vulkan::BufferFrameDataOptions().SetQueueFamilyIndex(app_->async_compute_queue()->index()));
 
     // Both compute passes use the same set of descriptors for simplicity.
     // Technically we don't have to pass the draw_data SSBO to the velocity

--- a/application_sandbox/compute_particles/main.cpp
+++ b/application_sandbox/compute_particles/main.cpp
@@ -75,8 +75,8 @@ class ComputeTask {
 
     update_time_data_ = containers::make_unique<vulkan::BufferFrameData<Mat44>>(
         allocator_, app_, app_->swapchain_images().size(),
-        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, 0,
-        app_->async_compute_queue()->index());
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        vulkan::BufferFrameDataOptions().SetQueueFamilyIndex(app_->async_compute_queue()->index()));
 
     InitSimulationSSBO();
     InitRenderSSBO();

--- a/application_sandbox/multigpu_particles/main.cpp
+++ b/application_sandbox/multigpu_particles/main.cpp
@@ -235,11 +235,11 @@ int main_entry(const entry::EntryData* data) {
   auto update_time_data =
       containers::make_unique<vulkan::BufferFrameData<Mat44>>(
           allocator, &app, kNBuffers, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-          kMaskGPU1);
+          vulkan::BufferFrameDataOptions().SetDeviceMask(kMaskGPU1));
   auto aspect_buffer =
       containers::make_unique<vulkan::BufferFrameData<Vector4>>(
           allocator, &app, kNBuffers, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-          kMaskGPU0);
+          vulkan::BufferFrameDataOptions().SetDeviceMask(kMaskGPU0));
 
   // Fill the buffer. Technically we probably want to use a staging buffer
   // and fill from that, since this is not really a "small" buffer.

--- a/application_sandbox/timeline_semaphore_cross_queue/main.cpp
+++ b/application_sandbox/timeline_semaphore_cross_queue/main.cpp
@@ -59,18 +59,19 @@ int main_entry(const entry::EntryData* data) {
   logging::Logger* log = data->logger();
   log->LogInfo("Application Startup");
 
-  VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features {
+  VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features{
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR,
       nullptr,
       VK_TRUE,
   };
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {
-      VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-  }, {
-      VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME
-  }, {}, 131072, 131072, 131072, 131072, true, false,  false, 0, false, false, VK_COLORSPACE_SRGB_NONLINEAR_KHR,
-    false, false, nullptr, true, false, &timeline_semaphore_features);
+  vulkan::VulkanApplication app(
+      data->allocator(), data->logger(), data,
+      {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME},
+      {VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME}, {}, 131072, 131072, 131072,
+      131072, true, false, false, 0, false, false,
+      VK_COLORSPACE_SRGB_NONLINEAR_KHR, false, false, nullptr, true, false,
+      &timeline_semaphore_features);
 
   vulkan::VkDevice& device = app.device();
 
@@ -191,7 +192,9 @@ int main_entry(const entry::EntryData* data) {
   containers::unique_ptr<vulkan::BufferFrameData<model_data_>> model_data =
       containers::make_unique<vulkan::BufferFrameData<model_data_>>(
           data->allocator(), &app, num_swapchain_images,
-          VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0, app.async_compute_queue()->index());
+          VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+          vulkan::BufferFrameDataOptions().SetQueueFamilyIndex(
+              app.async_compute_queue()->index()));
 
   camera_data->data().projection_matrix =
       Mat44::FromScaleVector(mathfu::Vector<float, 3>{1.0f, -1.0f, 1.0f}) *
@@ -205,22 +208,21 @@ int main_entry(const entry::EntryData* data) {
 
   for (int i = 0; i < num_swapchain_images; i++) {
     FrameData& frame_data_i = frame_data[i];
-    VkBufferCreateInfo create_info {
-        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
-        nullptr, // pNext
-        0, // flags
+    VkBufferCreateInfo create_info{
+        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,  // sType
+        nullptr,                               // pNext
+        0,                                     // flags
         sizeof(model_data_),
         VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
         VK_SHARING_MODE_EXCLUSIVE,
         0,
-        nullptr
-    };
+        nullptr};
     frame_data_i.model_buffer_ = app.CreateAndBindDeviceBuffer(&create_info);
     frame_data_i.rendered_fence = containers::make_unique<vulkan::VkFence>(
         data->allocator(), vulkan::CreateFence(&device, true));
     frame_data_i.copy_fence = containers::make_unique<vulkan::VkFence>(
         data->allocator(), vulkan::CreateFence(&device, true));
-    
+
     frame_data_i.swapchain_sema = containers::make_unique<vulkan::VkSemaphore>(
         data->allocator(), vulkan::CreateSemaphore(&device));
     frame_data_i.present_ready_sema =
@@ -249,10 +251,10 @@ int main_entry(const entry::EntryData* data) {
         containers::make_unique<vulkan::VkCommandBuffer>(
             data->allocator(), app.GetCommandBuffer());
 
-    frame_data_i.copy_model_buffer_ = 
+    frame_data_i.copy_model_buffer_ =
         containers::make_unique<vulkan::VkCommandBuffer>(
-            data->allocator(), app.GetCommandBuffer(app.async_compute_queue()->index())
-        );
+            data->allocator(),
+            app.GetCommandBuffer(app.async_compute_queue()->index()));
 
     frame_data_i.cube_descriptor_set_ =
         containers::make_unique<vulkan::DescriptorSet>(
@@ -267,11 +269,10 @@ int main_entry(const entry::EntryData* data) {
             camera_data->size(),                   // range
         },
         {
-            *frame_data_i.model_buffer_,             // buffer
-            0,                                       // offset
-            frame_data_i.model_buffer_->size(),      // range
-        }
-    };
+            *frame_data_i.model_buffer_,         // buffer
+            0,                                   // offset
+            frame_data_i.model_buffer_->size(),  // range
+        }};
 
     VkWriteDescriptorSet write{
         VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,  // sType
@@ -310,32 +311,29 @@ int main_entry(const entry::EntryData* data) {
 
     vulkan::VkCommandBuffer& copyBuffer = *frame_data_i.copy_model_buffer_;
 
-    copyBuffer->vkBeginCommandBuffer(copyBuffer, &sample_application::kBeginCommandBuffer);
-    VkBufferCopy region{
-        model_data->get_offset_for_frame(i),
-        0,
-        model_data->size()
-    };
+    copyBuffer->vkBeginCommandBuffer(copyBuffer,
+                                     &sample_application::kBeginCommandBuffer);
+    VkBufferCopy region{model_data->get_offset_for_frame(i), 0,
+                        model_data->size()};
 
-    copyBuffer->vkCmdCopyBuffer(copyBuffer, model_data->get_buffer(), 
-        *frame_data_i.model_buffer_, 1, &region);
+    copyBuffer->vkCmdCopyBuffer(copyBuffer, model_data->get_buffer(),
+                                *frame_data_i.model_buffer_, 1, &region);
 
     // Queue Ownership Release operation
     VkBufferMemoryBarrier barrier = {
         VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,  // sType
         nullptr,                                  // pNext
         VK_ACCESS_TRANSFER_WRITE_BIT,             // srcAccessMask
-        VK_ACCESS_TRANSFER_READ_BIT, // Unused    // dstAccessMask
+        VK_ACCESS_TRANSFER_READ_BIT,              // Unused    // dstAccessMask
         app.async_compute_queue()->index(),       // srcQueueFamilyIndex
         app.render_queue().index(),               // dstQueueFamilyIndex
         *frame_data_i.model_buffer_,              // buffer
         0,                                        //  offset
         frame_data_i.model_buffer_->size(),       // size
     };
-    copyBuffer->vkCmdPipelineBarrier(copyBuffer, 
-        VK_PIPELINE_STAGE_TRANSFER_BIT,
-        VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0,
-        nullptr);
+    copyBuffer->vkCmdPipelineBarrier(copyBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0,
+                                     nullptr, 1, &barrier, 0, nullptr);
     (*frame_data_i.copy_model_buffer_)
         ->vkEndCommandBuffer(*frame_data_i.copy_model_buffer_);
 
@@ -343,10 +341,9 @@ int main_entry(const entry::EntryData* data) {
     cmdBuffer->vkBeginCommandBuffer(cmdBuffer,
                                     &sample_application::kBeginCommandBuffer);
     // Transfer acquire operation
-    cmdBuffer->vkCmdPipelineBarrier(cmdBuffer, 
-    VK_PIPELINE_STAGE_TRANSFER_BIT,
-    VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0,
-    nullptr);
+    cmdBuffer->vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                    VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0,
+                                    nullptr, 1, &barrier, 0, nullptr);
     VkClearValue clear;
     // Make the clear color white.
     clear.color = {0.0, 0.0, 0.0, 1.0};
@@ -386,93 +383,91 @@ int main_entry(const entry::EntryData* data) {
       VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
   VkTimelineSemaphoreSubmitInfoKHR timelineSubmitInfos[] = {
       VkTimelineSemaphoreSubmitInfoKHR{
-          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR, // sType
-          nullptr,  // pNext 
-          1, // waitSemaphoreValueCount
-          &zero, // waitSemaphoreValues,
-          1, // signalSemaphoreValueCount
-          &signal_from_swap // signalSemaphoreValues
-      }, 
-      VkTimelineSemaphoreSubmitInfoKHR{
-          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR, // sType
-          nullptr,  // pNext 
-          1, // waitSemaphoreValueCount
-          &signal_from_second_queue, // waitSemaphoreValues,
-          1, // signalSemaphoreValueCount
-          &signal_to_swap // signalSemaphoreValues
+          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,  // sType
+          nullptr,                                               // pNext
+          1,                 // waitSemaphoreValueCount
+          &zero,             // waitSemaphoreValues,
+          1,                 // signalSemaphoreValueCount
+          &signal_from_swap  // signalSemaphoreValues
       },
       VkTimelineSemaphoreSubmitInfoKHR{
-          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR, // sType
-          nullptr,  // pNext 
-          1, // waitSemaphoreValueCount
-          &signal_to_swap, // waitSemaphoreValues,
-          1, // signalSemaphoreValueCount
-          &zero // signalSemaphoreValues
+          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,  // sType
+          nullptr,                                               // pNext
+          1,                          // waitSemaphoreValueCount
+          &signal_from_second_queue,  // waitSemaphoreValues,
+          1,                          // signalSemaphoreValueCount
+          &signal_to_swap             // signalSemaphoreValues
+      },
+      VkTimelineSemaphoreSubmitInfoKHR{
+          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,  // sType
+          nullptr,                                               // pNext
+          1,                // waitSemaphoreValueCount
+          &signal_to_swap,  // waitSemaphoreValues,
+          1,                // signalSemaphoreValueCount
+          &zero             // signalSemaphoreValues
       },
   };
 
-  VkSubmitInfo submit_infos[] = {
-    VkSubmitInfo{
-      VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-      &timelineSubmitInfos[0],        // pNext
-      1,                              // waitSemaphoreCount
-      nullptr,                        // pWaitSemaphores
-      &waitStageMask,                 // pWaitDstStageMask,
-      0,                              // commandBufferCount
-      nullptr,                        // pCommandBuffers
-      1,                              // signalSemaphoreCount
-      nullptr                         // pSignalSemaphores
-    }, VkSubmitInfo {
-      VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-      &timelineSubmitInfos[1],        // pNext
-      1,                              // waitSemaphoreCount
-      nullptr,                        // pWaitSemaphores
-      &waitStageMask,                 // pWaitDstStageMask,
-      1,                              // commandBufferCount
-      nullptr,                        //
-      1,                              // signalSemaphoreCount
-      nullptr                         // pSignalSemaphores
-    },
-    VkSubmitInfo {
-      VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-      &timelineSubmitInfos[2],        // pNext
-      1,                              // waitSemaphoreCount
-      nullptr,                        // pWaitSemaphores
-      &waitStageMask,                 // pWaitDstStageMask,
-      0,                              // commandBufferCount
-      nullptr,                        // pCommandBuffers
-      1,                              // signalSemaphoreCount
-      nullptr                         // pSignalSemaphores
-    }
-  };
+  VkSubmitInfo submit_infos[] = {VkSubmitInfo{
+                                     VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+                                     &timelineSubmitInfos[0],        // pNext
+                                     1,               // waitSemaphoreCount
+                                     nullptr,         // pWaitSemaphores
+                                     &waitStageMask,  // pWaitDstStageMask,
+                                     0,               // commandBufferCount
+                                     nullptr,         // pCommandBuffers
+                                     1,               // signalSemaphoreCount
+                                     nullptr          // pSignalSemaphores
+                                 },
+                                 VkSubmitInfo{
+                                     VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+                                     &timelineSubmitInfos[1],        // pNext
+                                     1,               // waitSemaphoreCount
+                                     nullptr,         // pWaitSemaphores
+                                     &waitStageMask,  // pWaitDstStageMask,
+                                     1,               // commandBufferCount
+                                     nullptr,         //
+                                     1,               // signalSemaphoreCount
+                                     nullptr          // pSignalSemaphores
+                                 },
+                                 VkSubmitInfo{
+                                     VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+                                     &timelineSubmitInfos[2],        // pNext
+                                     1,               // waitSemaphoreCount
+                                     nullptr,         // pWaitSemaphores
+                                     &waitStageMask,  // pWaitDstStageMask,
+                                     0,               // commandBufferCount
+                                     nullptr,         // pCommandBuffers
+                                     1,               // signalSemaphoreCount
+                                     nullptr          // pSignalSemaphores
+                                 }};
 
   // TimelineSemaphore
   auto timelineSemaphore = vulkan::CreateTimelineSemaphore(&device, 0);
-    
+
   VkTimelineSemaphoreSubmitInfoKHR timelineSubmitInfos2[] = {
-    VkTimelineSemaphoreSubmitInfoKHR{
-        VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR, // sType
-        nullptr,  // pNext 
-        1, // waitSemaphoreValueCount
-        &signal_from_swap, // waitSemaphoreValues,
-        1, // signalSemaphoreValueCount
-        &signal_from_second_queue // signalSemaphoreValues
-    },
+      VkTimelineSemaphoreSubmitInfoKHR{
+          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,  // sType
+          nullptr,                                               // pNext
+          1,                         // waitSemaphoreValueCount
+          &signal_from_swap,         // waitSemaphoreValues,
+          1,                         // signalSemaphoreValueCount
+          &signal_from_second_queue  // signalSemaphoreValues
+      },
   };
 
-
   VkSubmitInfo second_submit_infos[] = {
-    VkSubmitInfo{
-      VK_STRUCTURE_TYPE_SUBMIT_INFO,         // sType
-      &timelineSubmitInfos2[0],              // pNext
-      1,                                     // waitSemaphoreCount
-      &timelineSemaphore.get_raw_object(),   // pWaitSemaphores
-      &waitStageMask,                        // pWaitDstStageMask,
-      1,                                     // commandBufferCount
-      nullptr,                               // pCommandBuffers
-      1,                                     // signalSemaphoreCount
-      &timelineSemaphore.get_raw_object()    // pSignalSemaphores
-    },
+      VkSubmitInfo{
+          VK_STRUCTURE_TYPE_SUBMIT_INFO,        // sType
+          &timelineSubmitInfos2[0],             // pNext
+          1,                                    // waitSemaphoreCount
+          &timelineSemaphore.get_raw_object(),  // pWaitSemaphores
+          &waitStageMask,                       // pWaitDstStageMask,
+          1,                                    // commandBufferCount
+          nullptr,                              // pCommandBuffers
+          1,                                    // signalSemaphoreCount
+          &timelineSemaphore.get_raw_object()   // pSignalSemaphores
+      },
   };
 
   uint32_t i = 0;
@@ -499,8 +494,8 @@ int main_entry(const entry::EntryData* data) {
                           &frame_data_i.rendered_fence->get_raw_object());
 
     device->vkWaitForFences(device, 1,
-                            &frame_data_i.copy_fence->get_raw_object(),
-                            VK_TRUE, UINT64_MAX);
+                            &frame_data_i.copy_fence->get_raw_object(), VK_TRUE,
+                            UINT64_MAX);
     device->vkResetFences(device, 1,
                           &frame_data_i.copy_fence->get_raw_object());
     camera_data->UpdateBuffer(&app.render_queue(), image_i);
@@ -511,52 +506,48 @@ int main_entry(const entry::EntryData* data) {
         Mat44::FromRotationMatrix(Mat44::RotationX(3.14f * speed) *
                                   Mat44::RotationY(3.14f * speed * 0.5f));
 
-    // Now just have to submit a copy from model_data -> model_buffer. Using a timeline
-    // semaphore
- 
+    // Now just have to submit a copy from model_data -> model_buffer. Using a
+    // timeline semaphore
+
     signal_from_swap = signal_to_swap + 1;
     signal_from_second_queue = signal_from_swap + 1;
     signal_to_swap = signal_from_second_queue + 1;
 
     submit_infos[0].pWaitSemaphores =
         &frame_data[i].swapchain_sema->get_raw_object();
-    submit_infos[0].pSignalSemaphores =
-        &timelineSemaphore.get_raw_object();
-
+    submit_infos[0].pSignalSemaphores = &timelineSemaphore.get_raw_object();
 
     submit_infos[1].pCommandBuffers =
         &frame_data_i.command_buffer_->get_command_buffer();
-    submit_infos[1].pWaitSemaphores =
-        &timelineSemaphore.get_raw_object();
-    submit_infos[1].pSignalSemaphores =
-        &timelineSemaphore.get_raw_object();
+    submit_infos[1].pWaitSemaphores = &timelineSemaphore.get_raw_object();
+    submit_infos[1].pSignalSemaphores = &timelineSemaphore.get_raw_object();
 
-    submit_infos[2].pWaitSemaphores =
-        &timelineSemaphore.get_raw_object();
+    submit_infos[2].pWaitSemaphores = &timelineSemaphore.get_raw_object();
     submit_infos[2].pSignalSemaphores =
         &frame_data[i].present_ready_sema->get_raw_object();
-    
+
     second_submit_infos[0].pCommandBuffers =
         &frame_data_i.copy_model_buffer_->get_command_buffer();
-    
+
     // This submission should proceed through the first submit, then
     // wait
     LOG_ASSERT(==, log, VK_SUCCESS,
                app.render_queue()->vkQueueSubmit(
                    app.render_queue(), 3, &submit_infos[0],
                    frame_data_i.rendered_fence->get_raw_object()));
-    
+
     // This submission will wait until the first submission from the
-    // first queue is done, and then run the copy operation, 
+    // first queue is done, and then run the copy operation,
     // and then unblock the first submission
-    LOG_ASSERT(==, log, VK_SUCCESS, 
-        (*app.async_compute_queue())->vkQueueSubmit(
-            *app.async_compute_queue(), 1, &second_submit_infos[0],
-            frame_data_i.copy_fence->get_raw_object()));
-    
+    LOG_ASSERT(==, log, VK_SUCCESS,
+               (*app.async_compute_queue())
+                   ->vkQueueSubmit(*app.async_compute_queue(), 1,
+                                   &second_submit_infos[0],
+                                   frame_data_i.copy_fence->get_raw_object()));
+
     VkPresentInfoKHR present_info{
         VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,  // sType
-        nullptr        ,                     // pNext
+        nullptr,                             // pNext
         1,                                   // waitSemaphoreCount
         &frame_data[i++]
              .present_ready_sema->get_raw_object(),  // pWaitSemaphores


### PR DESCRIPTION
This PR adds support for explicitly specifying the offset alignment used in creating a BufferFrameData object. If not specified, the offset alignment will continue to be the maximum one allowed by the Vulkan spec (i.e. kMaxOffsetAlignment).

The set of optional of parameters (device_mask, queue_family_index and now offset_alignment) used when creating a BufferFrameData object have been refactored into a BufferFrameDataOptions struct to avoid having too many integer based, default value arguments in the constructor.