### PR TITLE
Remove legacy application options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,5 +120,5 @@ To build on Windows the following tools and libraries are required:
 [C++ Reference]: https://en.cppreference.com/w/cpp/17
 [CMake Version]: https://img.shields.io/badge/CMake-3.1-blue
 [CMake Reference]: https://cmake.org/cmake/help/v3.1
-[CI Badge]: https://github.com/google/vulkan_test_applications/actions/workflows/build.yml/badge.svg?branch=master
-[CI Workflow]: https://github.com/google/vulkan_test_applications/actions/workflows/build.yml?query=branch%3Amaster
+[Build Badge]: https://github.com/google/vulkan_test_applications/actions/workflows/build.yml/badge.svg?branch=master
+[Build Workflow]: https://github.com/google/vulkan_test_applications/actions/workflows/build.yml?query=branch%3Amaster

--- a/application_sandbox/compute_particles/main.cpp
+++ b/application_sandbox/compute_particles/main.cpp
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+
 #include "application_sandbox/sample_application_framework/sample_application.h"
+#include "particle_data_shared.h"
 #include "support/containers/deque.h"
 #include "support/entry/entry.h"
 #include "vulkan_helpers/buffer_frame_data.h"
@@ -20,15 +27,6 @@
 #include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_helpers/vulkan_model.h"
 #include "vulkan_helpers/vulkan_texture.h"
-
-#include "particle_data_shared.h"
-
-#include <chrono>
-
-#include <condition_variable>
-#include <functional>
-#include <mutex>
-#include <thread>
 
 namespace quad_model {
 #include "fullscreen_quad.obj.h"
@@ -76,7 +74,8 @@ class ComputeTask {
     update_time_data_ = containers::make_unique<vulkan::BufferFrameData<Mat44>>(
         allocator_, app_, app_->swapchain_images().size(),
         VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-        vulkan::BufferFrameDataOptions().SetQueueFamilyIndex(app_->async_compute_queue()->index()));
+        vulkan::BufferFrameDataOptions().SetQueueFamilyIndex(
+            app_->async_compute_queue()->index()));
 
     InitSimulationSSBO();
     InitRenderSSBO();
@@ -126,9 +125,9 @@ class ComputeTask {
         &waitStageMask,                 // pWaitDstStageMask,
         1,                              // commandBufferCount
         &(dat.command_buffer_.get_command_buffer()),
-        1,                              // signalSemaphoreCount
+        1,  // signalSemaphoreCount
         &GetSemaphoreForIndex(frame_index)
-             ->get_raw_object()         // pSignalSemaphores
+             ->get_raw_object()  // pSignalSemaphores
     };
 
     (*app_->async_compute_queue())
@@ -153,10 +152,10 @@ class ComputeTask {
         0,                                          // createFlags
         sizeof(simulation_data) * TOTAL_PARTICLES,  // size
         VK_BUFFER_USAGE_TRANSFER_DST_BIT |
-            VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,    // usageFlags
-        VK_SHARING_MODE_EXCLUSIVE,                 // sharingMode
-        0,                                         // queueFamilyIndexCount
-        nullptr                                    // pQueueFamilyIndices
+            VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,  // usageFlags
+        VK_SHARING_MODE_EXCLUSIVE,               // sharingMode
+        0,                                       // queueFamilyIndexCount
+        nullptr                                  // pQueueFamilyIndices
     };
 
     simulation_ssbo_ = app_->CreateAndBindDeviceBuffer(&create_info);
@@ -200,8 +199,8 @@ class ComputeTask {
         nullptr,                        // pWaitDstStageMask,
         1,                              // commandBufferCount
         &(initial_data_buffer->get_command_buffer()),
-        0,                             // signalSemaphoreCount
-        nullptr                        // pSignalSemaphores
+        0,       // signalSemaphoreCount
+        nullptr  // pSignalSemaphores
     };
 
     // Actually finish filling the initial data, and transfer to the
@@ -631,7 +630,7 @@ class ComputeParticlesSample
         nullptr,                        // pWaitDstStageMask,
         0,                              // commandBufferCount
         nullptr,
-        1,                              // signalSemaphoreCount
+        1,  // signalSemaphoreCount
         &frame_data->render_semaphore_->get_raw_object()  // pSignalSemaphores
     };
 

--- a/application_sandbox/external_buffer/buffer_export.cpp
+++ b/application_sandbox/external_buffer/buffer_export.cpp
@@ -42,6 +42,7 @@ int main_entry(const entry::EntryData* data) {
 
   vulkan::VulkanApplication app(
       data->allocator(), data->logger(), data,
+      vulkan::VulkanApplicationOptions(),
       {VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
        VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME},
       {VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,

--- a/application_sandbox/external_image/image_export.cpp
+++ b/application_sandbox/external_image/image_export.cpp
@@ -161,6 +161,7 @@ int main_entry(const entry::EntryData* data) {
 
   vulkan::VulkanApplication app(
       data->allocator(), data->logger(), data,
+      vulkan::VulkanApplicationOptions(),
       {VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
        VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME},
       {VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,

--- a/application_sandbox/foreign_buffer/buffer_export.cpp
+++ b/application_sandbox/foreign_buffer/buffer_export.cpp
@@ -42,6 +42,7 @@ int main_entry(const entry::EntryData* data) {
 
   vulkan::VulkanApplication app(
       data->allocator(), data->logger(), data,
+      vulkan::VulkanApplicationOptions(),
       {VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
        VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME},
       {VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,

--- a/application_sandbox/multigpu_particles/main.cpp
+++ b/application_sandbox/multigpu_particles/main.cpp
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+
 #include "application_sandbox/sample_application_framework/sample_application.h"
+#include "particle_data_shared.h"
 #include "support/containers/deque.h"
 #include "support/entry/entry.h"
 #include "vulkan_helpers/buffer_frame_data.h"
@@ -20,15 +27,6 @@
 #include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_helpers/vulkan_model.h"
 #include "vulkan_helpers/vulkan_texture.h"
-
-#include "particle_data_shared.h"
-
-#include <chrono>
-
-#include <condition_variable>
-#include <functional>
-#include <mutex>
-#include <thread>
 
 const VkCommandBufferBeginInfo kBeginCommandBuffer = {
     VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,  // sType
@@ -96,11 +94,15 @@ const VkCommandBufferBeginInfo kBeginCommandBufferOn0 = {
 int main_entry(const entry::EntryData* data) {
   auto* allocator = data->allocator();
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {}, {},
-                                VkPhysicalDeviceFeatures{}, 1024 * 1024 * 256,
-                                1024 * 1024 * 256, 1024 * 1024 * 512,
-                                1024 * 1024 * 256, false, false, true,
-                                1024 * 1024 * 256, false, true);
+
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions()
+                                    .SetHostBufferSize(1024 * 1024 * 256)
+                                    .SetDeviceImageSize(1024 * 1024 * 256)
+                                    .SetDeviceBufferSize(1024 * 1024 * 512)
+                                    .EnableDeviceGroups()
+                                    .SetDevicePeerMemorySize(1024 * 1024 * 256)
+                                    .EnableHostQueryReset());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
   vulkan::VkQueue& render_queue = app.render_queue();

--- a/application_sandbox/overlapping_frames/main.cpp
+++ b/application_sandbox/overlapping_frames/main.cpp
@@ -408,12 +408,12 @@ int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Start app: overlapping_frames");
 
   const uint32_t min_swapchain_image_count = 2;
-  const uint32_t default_size = 1024 * 1024;
+
   vulkan::VulkanApplication app(
-      data->allocator(), data->logger(), data, {}, {}, {0}, default_size,
-      default_size, default_size, default_size, false, false, false, 0, false,
-      false, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR, false, false, nullptr, false,
-      false, nullptr, min_swapchain_image_count);
+      data->allocator(), data->logger(), data,
+      vulkan::VulkanApplicationOptions().SetMinSwapchainImageCount(
+          min_swapchain_image_count),
+      {}, {});
 
   auto sampler_images = buildSamplerImages(&app, data);
   vulkan::VulkanModel screen(data->allocator(), data->logger(), screen_data);

--- a/application_sandbox/pipeline_executable_properties/main.cpp
+++ b/application_sandbox/pipeline_executable_properties/main.cpp
@@ -40,11 +40,15 @@ int main_entry(const entry::EntryData* data) {
           nullptr, true};
 
   vulkan::VulkanApplication app(
-      data->allocator(), data->logger(), data, {},
-      {VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME}, {0}, 1024 * 128,
-      1024 * 128, 1024 * 128, 1024 * 128, false, false, false, 0, false, false,
-        VK_COLOR_SPACE_SRGB_NONLINEAR_KHR, false, false, nullptr, false, false,
-        &pipeline_executable_info_features);
+      data->allocator(), data->logger(), data,
+      vulkan::VulkanApplicationOptions()
+          .SetHostBufferSize(1024 * 128)
+          .SetDeviceImageSize(1024 * 128)
+          .SetDeviceBufferSize(1024 * 128)
+          .SetCoherentBufferSize(1024 * 128)
+          .SetSwapchainColorSpace(VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+          .SetDeviceExtensions(&pipeline_executable_info_features),
+      {}, {VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME});
 
   vulkan::VkDevice& device = app.device();
 

--- a/application_sandbox/simple_compute/main.cpp
+++ b/application_sandbox/simple_compute/main.cpp
@@ -27,7 +27,8 @@ uint32_t compute_shader[] =
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
 
   const uint32_t kOutputBuffer =

--- a/application_sandbox/timeline_semaphore_cross_queue/main.cpp
+++ b/application_sandbox/timeline_semaphore_cross_queue/main.cpp
@@ -67,11 +67,16 @@ int main_entry(const entry::EntryData* data) {
 
   vulkan::VulkanApplication app(
       data->allocator(), data->logger(), data,
+      vulkan::VulkanApplicationOptions()
+          .SetHostBufferSize(131072)
+          .SetDeviceImageSize(131072)
+          .SetDeviceBufferSize(131072)
+          .SetCoherentBufferSize(131072)
+          .SetVulkanApiVersion(VK_API_VERSION_1_1)
+          .EnableAsyncComputeQueue()
+          .SetDeviceExtensions(&timeline_semaphore_features),
       {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME},
-      {VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME}, {}, 131072, 131072, 131072,
-      131072, true, false, false, 0, false, false,
-      VK_COLORSPACE_SRGB_NONLINEAR_KHR, false, false, nullptr, true, false,
-      &timeline_semaphore_features);
+      {VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME});
 
   vulkan::VkDevice& device = app.device();
 

--- a/application_sandbox/timeline_semaphore_simple/main.cpp
+++ b/application_sandbox/timeline_semaphore_simple/main.cpp
@@ -56,18 +56,23 @@ int main_entry(const entry::EntryData* data) {
   logging::Logger* log = data->logger();
   log->LogInfo("Application Startup");
 
-  VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features {
+  VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features{
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR,
       nullptr,
       VK_TRUE,
   };
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {
-      VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-  }, {
-      VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME
-  }, {}, 131072, 131072, 131072, 131072, false, false,  false, 0, false, false, VK_COLORSPACE_SRGB_NONLINEAR_KHR, 
-    false, false, nullptr, true, false, &timeline_semaphore_features);
+  vulkan::VulkanApplication app(
+      data->allocator(), data->logger(), data,
+      vulkan::VulkanApplicationOptions()
+          .SetHostBufferSize(131072)
+          .SetDeviceImageSize(131072)
+          .SetDeviceBufferSize(131072)
+          .SetCoherentBufferSize(131072)
+          .SetVulkanApiVersion(VK_API_VERSION_1_1)
+          .SetDeviceExtensions(&timeline_semaphore_features),
+      {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME},
+      {VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME});
 
   vulkan::VkDevice& device = app.device();
 
@@ -328,69 +333,68 @@ int main_entry(const entry::EntryData* data) {
       VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
   VkTimelineSemaphoreSubmitInfoKHR timelineSubmitInfos[] = {
       VkTimelineSemaphoreSubmitInfoKHR{
-          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR, // sType
-          nullptr,  // pNext 
-          1, // waitSemaphoreValueCount
-          &zero, // waitSemaphoreValues,
-          1, // signalSemaphoreValueCount
-          &signal_from_swap // signalSemaphoreValues
-      }, 
-      VkTimelineSemaphoreSubmitInfoKHR{
-          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR, // sType
-          nullptr,  // pNext 
-          1, // waitSemaphoreValueCount
-          &signal_from_swap, // waitSemaphoreValues,
-          1, // signalSemaphoreValueCount
-          &signal_to_swap // signalSemaphoreValues
+          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,  // sType
+          nullptr,                                               // pNext
+          1,                 // waitSemaphoreValueCount
+          &zero,             // waitSemaphoreValues,
+          1,                 // signalSemaphoreValueCount
+          &signal_from_swap  // signalSemaphoreValues
       },
       VkTimelineSemaphoreSubmitInfoKHR{
-          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR, // sType
-          nullptr,  // pNext 
-          1, // waitSemaphoreValueCount
-          &signal_to_swap, // waitSemaphoreValues,
-          1, // signalSemaphoreValueCount
-          &zero // signalSemaphoreValues
+          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,  // sType
+          nullptr,                                               // pNext
+          1,                  // waitSemaphoreValueCount
+          &signal_from_swap,  // waitSemaphoreValues,
+          1,                  // signalSemaphoreValueCount
+          &signal_to_swap     // signalSemaphoreValues
+      },
+      VkTimelineSemaphoreSubmitInfoKHR{
+          VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,  // sType
+          nullptr,                                               // pNext
+          1,                // waitSemaphoreValueCount
+          &signal_to_swap,  // waitSemaphoreValues,
+          1,                // signalSemaphoreValueCount
+          &zero             // signalSemaphoreValues
       },
   };
 
-  VkSubmitInfo submit_infos[] = {
-    VkSubmitInfo{
-      VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-      &timelineSubmitInfos[0],        // pNext
-      1,                              // waitSemaphoreCount
-      nullptr,                        // pWaitSemaphores
-      &waitStageMask,                 // pWaitDstStageMask,
-      0,                              // commandBufferCount
-      nullptr,                        // pCommandBuffers
-      1,                              // signalSemaphoreCount
-      nullptr                         // pSignalSemaphores
-    }, VkSubmitInfo {
-      VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-      &timelineSubmitInfos[1],        // pNext
-      1,                              // waitSemaphoreCount
-      nullptr,                        // pWaitSemaphores
-      &waitStageMask,                 // pWaitDstStageMask,
-      1,                              // commandBufferCount
-      nullptr,                        //
-      1,                              // signalSemaphoreCount
-      nullptr                         // pSignalSemaphores
-    },
-    VkSubmitInfo {
-      VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-      &timelineSubmitInfos[2],        // pNext
-      1,                              // waitSemaphoreCount
-      nullptr,                        // pWaitSemaphores
-      &waitStageMask,                 // pWaitDstStageMask,
-      0,                              // commandBufferCount
-      nullptr,                        // pCommandBuffers
-      1,                              // signalSemaphoreCount
-      nullptr                         // pSignalSemaphores
-    }
-  };
+  VkSubmitInfo submit_infos[] = {VkSubmitInfo{
+                                     VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+                                     &timelineSubmitInfos[0],        // pNext
+                                     1,               // waitSemaphoreCount
+                                     nullptr,         // pWaitSemaphores
+                                     &waitStageMask,  // pWaitDstStageMask,
+                                     0,               // commandBufferCount
+                                     nullptr,         // pCommandBuffers
+                                     1,               // signalSemaphoreCount
+                                     nullptr          // pSignalSemaphores
+                                 },
+                                 VkSubmitInfo{
+                                     VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+                                     &timelineSubmitInfos[1],        // pNext
+                                     1,               // waitSemaphoreCount
+                                     nullptr,         // pWaitSemaphores
+                                     &waitStageMask,  // pWaitDstStageMask,
+                                     1,               // commandBufferCount
+                                     nullptr,         //
+                                     1,               // signalSemaphoreCount
+                                     nullptr          // pSignalSemaphores
+                                 },
+                                 VkSubmitInfo{
+                                     VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+                                     &timelineSubmitInfos[2],        // pNext
+                                     1,               // waitSemaphoreCount
+                                     nullptr,         // pWaitSemaphores
+                                     &waitStageMask,  // pWaitDstStageMask,
+                                     0,               // commandBufferCount
+                                     nullptr,         // pCommandBuffers
+                                     1,               // signalSemaphoreCount
+                                     nullptr          // pSignalSemaphores
+                                 }};
 
   // TimelineSemaphore
   auto timelineSemaphore = vulkan::CreateTimelineSemaphore(&device, 0);
-    
+
   uint32_t i = 0;
   auto last_frame_time = std::chrono::high_resolution_clock::now();
   while (true) {
@@ -427,19 +431,14 @@ int main_entry(const entry::EntryData* data) {
 
     submit_infos[0].pWaitSemaphores =
         &frame_data[i].swapchain_sema->get_raw_object();
-    submit_infos[0].pSignalSemaphores =
-        &timelineSemaphore.get_raw_object();
-
+    submit_infos[0].pSignalSemaphores = &timelineSemaphore.get_raw_object();
 
     submit_infos[1].pCommandBuffers =
         &frame_data_i.command_buffer_->get_command_buffer();
-    submit_infos[1].pWaitSemaphores =
-        &timelineSemaphore.get_raw_object();
-    submit_infos[1].pSignalSemaphores =
-        &timelineSemaphore.get_raw_object();
+    submit_infos[1].pWaitSemaphores = &timelineSemaphore.get_raw_object();
+    submit_infos[1].pSignalSemaphores = &timelineSemaphore.get_raw_object();
 
-    submit_infos[2].pWaitSemaphores =
-        &timelineSemaphore.get_raw_object();
+    submit_infos[2].pWaitSemaphores = &timelineSemaphore.get_raw_object();
     submit_infos[2].pSignalSemaphores =
         &frame_data[i].present_ready_sema->get_raw_object();
 
@@ -450,7 +449,7 @@ int main_entry(const entry::EntryData* data) {
 
     VkPresentInfoKHR present_info{
         VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,  // sType
-        nullptr        ,                     // pNext
+        nullptr,                             // pNext
         1,                                   // waitSemaphoreCount
         &frame_data[i++]
              .present_ready_sema->get_raw_object(),  // pWaitSemaphores

--- a/application_sandbox/wait_fence_partial/main.cpp
+++ b/application_sandbox/wait_fence_partial/main.cpp
@@ -20,25 +20,25 @@
 #include "support/containers/vector.h"
 #include "support/entry/entry.h"
 #include "vulkan_core.h"
-#include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_helpers/helper_functions.h"
+#include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_helpers/vulkan_model.h"
 #include "vulkan_wrapper/command_buffer_wrapper.h"
 #include "vulkan_wrapper/descriptor_set_wrapper.h"
 #include "vulkan_wrapper/sub_objects.h"
 
 struct FrameData {
-    containers::unique_ptr<vulkan::VkCommandBuffer> gCommandBuffer;
-    containers::unique_ptr<vulkan::VkCommandBuffer> postCommandBuffer;
+  containers::unique_ptr<vulkan::VkCommandBuffer> gCommandBuffer;
+  containers::unique_ptr<vulkan::VkCommandBuffer> postCommandBuffer;
 
-    containers::unique_ptr<vulkan::VkSemaphore> gRenderFinished;
-    containers::unique_ptr<vulkan::VkSemaphore> imageAcquired;
-    containers::unique_ptr<vulkan::VkSemaphore> postRenderFinished;
+  containers::unique_ptr<vulkan::VkSemaphore> gRenderFinished;
+  containers::unique_ptr<vulkan::VkSemaphore> imageAcquired;
+  containers::unique_ptr<vulkan::VkSemaphore> postRenderFinished;
 
-    containers::unique_ptr<vulkan::VkFence> renderingFence;
-    containers::unique_ptr<vulkan::VkFence> postProcessFence;
+  containers::unique_ptr<vulkan::VkFence> renderingFence;
+  containers::unique_ptr<vulkan::VkFence> postProcessFence;
 
-    containers::unique_ptr<vulkan::DescriptorSet> descriptorSet;
+  containers::unique_ptr<vulkan::DescriptorSet> descriptorSet;
 };
 
 namespace gBuffer {
@@ -49,7 +49,7 @@ uint32_t vert[] =
 uint32_t frag[] =
 #include "triangle.frag.spv"
     ;
-};
+};  // namespace gBuffer
 
 namespace postBuffer {
 uint32_t vert[] =
@@ -59,16 +59,14 @@ uint32_t vert[] =
 uint32_t frag[] =
 #include "postprocessing.frag.spv"
     ;
-};
+};  // namespace postBuffer
 
 namespace screen_model {
 #include "fullscreen_quad.obj.h"
 }
 const auto& screen_data = screen_model::model;
 
-
 const size_t COLOR_BUFFER_SIZE = sizeof(float) * 3;
-
 
 const float colors[3][3] = {
     {1.0f, 1.0f, 0.0f},
@@ -76,582 +74,536 @@ const float colors[3][3] = {
     {0.0f, 1.0f, 1.0f},
 };
 
-vulkan::VkRenderPass buildRenderPass(
-    vulkan::VulkanApplication *app,
-    VkImageLayout initial_layout,
-    VkImageLayout final_layout) {
+vulkan::VkRenderPass buildRenderPass(vulkan::VulkanApplication* app,
+                                     VkImageLayout initial_layout,
+                                     VkImageLayout final_layout) {
+  // Build render pass
+  VkAttachmentReference color_attachment = {
+      0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  vulkan::VkRenderPass render_pass = app->CreateRenderPass(
+      {{
+          0,                                 // flags
+          app->swapchain().format(),         // format
+          VK_SAMPLE_COUNT_1_BIT,             // samples
+          VK_ATTACHMENT_LOAD_OP_CLEAR,       // loadOp
+          VK_ATTACHMENT_STORE_OP_STORE,      // storeOp
+          VK_ATTACHMENT_LOAD_OP_DONT_CARE,   // stencilLoadOp
+          VK_ATTACHMENT_STORE_OP_DONT_CARE,  // stencilStoreOp
+          initial_layout,                    // initialLayout
+          final_layout                       // finalLayout
+      }},                                    // AttachmentDescriptions
+      {{
+          0,                                // flags
+          VK_PIPELINE_BIND_POINT_GRAPHICS,  // pipelineBindPoint
+          0,                                // inputAttachmentCount
+          nullptr,                          // pInputAttachments
+          1,                                // colorAttachmentCount
+          &color_attachment,                // colorAttachment
+          nullptr,                          // pResolveAttachments
+          nullptr,                          // pDepthStencilAttachment
+          0,                                // preserveAttachmentCount
+          nullptr                           // pPreserveAttachments
+      }},                                   // SubpassDescriptions
+      {{
+          VK_SUBPASS_EXTERNAL,                            // srcSubpass
+          0,                                              // dstSubpass
+          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,  // srcStageMask
+          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,  // dstStageMsdk
+          0,                                              // srcAccessMask
+          VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,  // dstAccessMask
+          0                                          // dependencyFlags
+      }});
 
-    // Build render pass
-    VkAttachmentReference color_attachment = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-    vulkan::VkRenderPass render_pass = app->CreateRenderPass(
-        {{
-           0,                                // flags
-           app->swapchain().format(),        // format
-           VK_SAMPLE_COUNT_1_BIT,            // samples
-           VK_ATTACHMENT_LOAD_OP_CLEAR,      // loadOp
-           VK_ATTACHMENT_STORE_OP_STORE,     // storeOp
-           VK_ATTACHMENT_LOAD_OP_DONT_CARE,  // stencilLoadOp
-           VK_ATTACHMENT_STORE_OP_DONT_CARE, // stencilStoreOp
-           initial_layout,                   // initialLayout
-           final_layout                      // finalLayout
-        }},                                  // AttachmentDescriptions
-        {{
-           0,                                // flags
-           VK_PIPELINE_BIND_POINT_GRAPHICS,  // pipelineBindPoint
-           0,                                // inputAttachmentCount
-           nullptr,                          // pInputAttachments
-           1,                                // colorAttachmentCount
-           &color_attachment,                // colorAttachment
-           nullptr,                          // pResolveAttachments
-           nullptr,                          // pDepthStencilAttachment
-           0,                                // preserveAttachmentCount
-           nullptr                           // pPreserveAttachments
-        }},                                  // SubpassDescriptions
-        {{
-           VK_SUBPASS_EXTERNAL,                             // srcSubpass
-           0,                                               // dstSubpass
-           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,   // srcStageMask
-           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,   // dstStageMsdk
-           0,                                               // srcAccessMask
-           VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-           VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,            // dstAccessMask
-           0                                                // dependencyFlags
-        }}
-    );
-
-    return render_pass;
+  return render_pass;
 }
 
 vulkan::VulkanGraphicsPipeline buildTrianglePipeline(
-    vulkan::VulkanApplication *app,
-    vulkan::VkRenderPass* render_pass) {
-    // Build Triangle Pipeline
-    vulkan::PipelineLayout pipeline_layout(app->CreatePipelineLayout({{}}));
-    vulkan::VulkanGraphicsPipeline pipeline = app->CreateGraphicsPipeline(&pipeline_layout, render_pass, 0);
+    vulkan::VulkanApplication* app, vulkan::VkRenderPass* render_pass) {
+  // Build Triangle Pipeline
+  vulkan::PipelineLayout pipeline_layout(app->CreatePipelineLayout({{}}));
+  vulkan::VulkanGraphicsPipeline pipeline =
+      app->CreateGraphicsPipeline(&pipeline_layout, render_pass, 0);
 
-    vulkan::VulkanGraphicsPipeline::InputStream input_stream{
-        0,                           // binding
-        VK_FORMAT_R32G32B32_SFLOAT,  // format
-        0                            // offset
-    };
-    
-    pipeline.AddInputStream(COLOR_BUFFER_SIZE,VK_VERTEX_INPUT_RATE_VERTEX, {input_stream});
-    pipeline.AddShader(VK_SHADER_STAGE_VERTEX_BIT, "main", gBuffer::vert);
-    pipeline.AddShader(VK_SHADER_STAGE_FRAGMENT_BIT, "main", gBuffer::frag);
+  vulkan::VulkanGraphicsPipeline::InputStream input_stream{
+      0,                           // binding
+      VK_FORMAT_R32G32B32_SFLOAT,  // format
+      0                            // offset
+  };
 
-    pipeline.SetTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
-    pipeline.SetScissor({
-        {0, 0},                                                 // offset
-        {app->swapchain().width(), app->swapchain().height()}   // extent
-    });
-    pipeline.SetViewport({
-        0.0f,                                           // x
-        0.0f,                                           // y
-        static_cast<float>(app->swapchain().width()),   // width
-        static_cast<float>(app->swapchain().height()),  // height
-        0.0f,                                           // minDepth
-        1.0f                                            // maxDepth
-    });
-    pipeline.SetSamples(VK_SAMPLE_COUNT_1_BIT);
-    pipeline.AddAttachment();
-    pipeline.Commit();
+  pipeline.AddInputStream(COLOR_BUFFER_SIZE, VK_VERTEX_INPUT_RATE_VERTEX,
+                          {input_stream});
+  pipeline.AddShader(VK_SHADER_STAGE_VERTEX_BIT, "main", gBuffer::vert);
+  pipeline.AddShader(VK_SHADER_STAGE_FRAGMENT_BIT, "main", gBuffer::frag);
 
-    return pipeline;
+  pipeline.SetTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
+  pipeline.SetScissor({
+      {0, 0},                                                // offset
+      {app->swapchain().width(), app->swapchain().height()}  // extent
+  });
+  pipeline.SetViewport({
+      0.0f,                                           // x
+      0.0f,                                           // y
+      static_cast<float>(app->swapchain().width()),   // width
+      static_cast<float>(app->swapchain().height()),  // height
+      0.0f,                                           // minDepth
+      1.0f                                            // maxDepth
+  });
+  pipeline.SetSamples(VK_SAMPLE_COUNT_1_BIT);
+  pipeline.AddAttachment();
+  pipeline.Commit();
+
+  return pipeline;
 }
 
 vulkan::VulkanGraphicsPipeline buildPostPipeline(
-    vulkan::VulkanApplication *app,
-    vulkan::PipelineLayout* pipeline_layout,
-    vulkan::VkRenderPass* render_pass,
-    vulkan::VulkanModel* screen) {
-    // Build Post Pipeline
-    vulkan::VulkanGraphicsPipeline pipeline = app->CreateGraphicsPipeline(pipeline_layout, render_pass, 0);
+    vulkan::VulkanApplication* app, vulkan::PipelineLayout* pipeline_layout,
+    vulkan::VkRenderPass* render_pass, vulkan::VulkanModel* screen) {
+  // Build Post Pipeline
+  vulkan::VulkanGraphicsPipeline pipeline =
+      app->CreateGraphicsPipeline(pipeline_layout, render_pass, 0);
 
-    pipeline.AddShader(VK_SHADER_STAGE_VERTEX_BIT, "main", postBuffer::vert);
-    pipeline.AddShader(VK_SHADER_STAGE_FRAGMENT_BIT, "main", postBuffer::frag);
+  pipeline.AddShader(VK_SHADER_STAGE_VERTEX_BIT, "main", postBuffer::vert);
+  pipeline.AddShader(VK_SHADER_STAGE_FRAGMENT_BIT, "main", postBuffer::frag);
 
-    pipeline.SetTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
-    pipeline.SetInputStreams(screen);
-    pipeline.SetScissor({
-        {0, 0},                                                 // offset
-        {app->swapchain().width(), app->swapchain().height()}   // extent
-    });
-    pipeline.SetViewport({
-        0.0f,                                           // x
-        0.0f,                                           // y
-        static_cast<float>(app->swapchain().width()),   // width
-        static_cast<float>(app->swapchain().height()),  // height
-        0.0f,                                           // minDepth
-        1.0f                                            // maxDepth
-    });
-    pipeline.SetSamples(VK_SAMPLE_COUNT_1_BIT);
-    pipeline.AddAttachment();
-    pipeline.Commit();
+  pipeline.SetTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
+  pipeline.SetInputStreams(screen);
+  pipeline.SetScissor({
+      {0, 0},                                                // offset
+      {app->swapchain().width(), app->swapchain().height()}  // extent
+  });
+  pipeline.SetViewport({
+      0.0f,                                           // x
+      0.0f,                                           // y
+      static_cast<float>(app->swapchain().width()),   // width
+      static_cast<float>(app->swapchain().height()),  // height
+      0.0f,                                           // minDepth
+      1.0f                                            // maxDepth
+  });
+  pipeline.SetSamples(VK_SAMPLE_COUNT_1_BIT);
+  pipeline.AddAttachment();
+  pipeline.Commit();
 
-    return pipeline;
+  return pipeline;
 }
 
 containers::vector<vulkan::ImagePointer> buildSamplerImages(
-    vulkan::VulkanApplication *app,
-    const entry::EntryData* data) {
-    containers::vector<vulkan::ImagePointer> images(data->allocator());
-    images.reserve(app->swapchain_images().size());
+    vulkan::VulkanApplication* app, const entry::EntryData* data) {
+  containers::vector<vulkan::ImagePointer> images(data->allocator());
+  images.reserve(app->swapchain_images().size());
 
-    for(int index=0; index<app->swapchain_images().size(); index++) {
-        VkImageCreateInfo image_create_info = {
-            VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,    // sType
-            nullptr,                                // pNext
-            0,                                      // flags
-            VK_IMAGE_TYPE_2D,                       // imageType
-            app->swapchain().format(),              // format
-            {
-                app->swapchain().width(),           // width
-                app->swapchain().height(),          // height
-                1                                   // depth
-            },                                      // extent
-            1,                                      // mipLevels
-            1,                                      // arrayLayers
-            VK_SAMPLE_COUNT_1_BIT,                  // samples
-            VK_IMAGE_TILING_OPTIMAL,                // tiling
-            VK_IMAGE_USAGE_SAMPLED_BIT |
-            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,    // usage
-            VK_SHARING_MODE_EXCLUSIVE,              // sharingMode
-            0,                                      // queueFamilyIndexCount
-            nullptr,                                // pQueueFamilyIndices
-            VK_IMAGE_LAYOUT_UNDEFINED               // initialLayout
-        };
-        images.push_back(app->CreateAndBindImage(&image_create_info));
-    }
+  for (int index = 0; index < app->swapchain_images().size(); index++) {
+    VkImageCreateInfo image_create_info = {
+        VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,  // sType
+        nullptr,                              // pNext
+        0,                                    // flags
+        VK_IMAGE_TYPE_2D,                     // imageType
+        app->swapchain().format(),            // format
+        {
+            app->swapchain().width(),   // width
+            app->swapchain().height(),  // height
+            1                           // depth
+        },                              // extent
+        1,                              // mipLevels
+        1,                              // arrayLayers
+        VK_SAMPLE_COUNT_1_BIT,          // samples
+        VK_IMAGE_TILING_OPTIMAL,        // tiling
+        VK_IMAGE_USAGE_SAMPLED_BIT |
+            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,  // usage
+        VK_SHARING_MODE_EXCLUSIVE,                // sharingMode
+        0,                                        // queueFamilyIndexCount
+        nullptr,                                  // pQueueFamilyIndices
+        VK_IMAGE_LAYOUT_UNDEFINED                 // initialLayout
+    };
+    images.push_back(app->CreateAndBindImage(&image_create_info));
+  }
 
-    return images;
+  return images;
 }
 
 containers::vector<vulkan::VkImageView> buildSwapchainImageViews(
-    vulkan::VulkanApplication *app,
-    const entry::EntryData* data) {
-    containers::vector<vulkan::VkImageView> image_views(data->allocator());
-    image_views.reserve(app->swapchain_images().size());
+    vulkan::VulkanApplication* app, const entry::EntryData* data) {
+  containers::vector<vulkan::VkImageView> image_views(data->allocator());
+  image_views.reserve(app->swapchain_images().size());
 
-    for(int index=0; index < app->swapchain_images().size(); index++) {
-        VkImage& swapchain_image = app->swapchain_images()[index];
+  for (int index = 0; index < app->swapchain_images().size(); index++) {
+    VkImage& swapchain_image = app->swapchain_images()[index];
 
-        VkImageViewCreateInfo image_view_create_info {
-            VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
-            nullptr,                                   // pNext
-            0,                                         // flags
-            swapchain_image,                           // image
-            VK_IMAGE_VIEW_TYPE_2D,                     // viewType
-            app->swapchain().format(),                 // format
-            {
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.r
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.g
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.b
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.a
-            },
-            {
-                VK_IMAGE_ASPECT_COLOR_BIT,  // subresourceRange.aspectMask
-                0,                          // subresourceRange.baseMipLevel
-                1,                          // subresourceRange.levelCount
-                0,                          // subresourceRange.baseArrayLayer
-                1,                          // subresourceRange.layerCount
-            },
-        };
+    VkImageViewCreateInfo image_view_create_info{
+        VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
+        nullptr,                                   // pNext
+        0,                                         // flags
+        swapchain_image,                           // image
+        VK_IMAGE_VIEW_TYPE_2D,                     // viewType
+        app->swapchain().format(),                 // format
+        {
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.r
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.g
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.b
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.a
+        },
+        {
+            VK_IMAGE_ASPECT_COLOR_BIT,  // subresourceRange.aspectMask
+            0,                          // subresourceRange.baseMipLevel
+            1,                          // subresourceRange.levelCount
+            0,                          // subresourceRange.baseArrayLayer
+            1,                          // subresourceRange.layerCount
+        },
+    };
 
-        VkImageView raw_image_view;
-        LOG_ASSERT(==, data->logger(), app->device()->vkCreateImageView(
-            app->device(),
-            &image_view_create_info,
-            nullptr,
-            &raw_image_view
-        ), VK_SUCCESS);
-        image_views.push_back(vulkan::VkImageView(raw_image_view, nullptr, &app->device()));
-    }
+    VkImageView raw_image_view;
+    LOG_ASSERT(
+        ==, data->logger(),
+        app->device()->vkCreateImageView(app->device(), &image_view_create_info,
+                                         nullptr, &raw_image_view),
+        VK_SUCCESS);
+    image_views.push_back(
+        vulkan::VkImageView(raw_image_view, nullptr, &app->device()));
+  }
 
-    return image_views;
+  return image_views;
 }
 
 vulkan::DescriptorSet buildDescriptorSet(
-    vulkan::VulkanApplication *app,
-    const vulkan::VkSampler& sampler,
+    vulkan::VulkanApplication* app, const vulkan::VkSampler& sampler,
     const vulkan::VkImageView& image_view) {
-    auto descriptor_set = app->AllocateDescriptorSet({{
-        0,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        1,
-        VK_SHADER_STAGE_FRAGMENT_BIT,
-        nullptr
-    }});
+  auto descriptor_set =
+      app->AllocateDescriptorSet({{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                   1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}});
 
-    VkDescriptorImageInfo image_info = {
-        sampler.get_raw_object(),
-        image_view.get_raw_object(),
-        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
-    };
+  VkDescriptorImageInfo image_info = {sampler.get_raw_object(),
+                                      image_view.get_raw_object(),
+                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
 
-    VkWriteDescriptorSet write{
-        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,    // sType
-        nullptr,                                   // pNext
-        descriptor_set,                            // dstSet
-        0,                                         // dstbinding
-        0,                                         // dstArrayElement
-        1,                                         // descriptorCount
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, // descriptorType
-        &image_info,                               // pImageInfo
-        nullptr,                                   // pBufferInfo
-        nullptr,                                   // pTexelBufferView
-    };
+  VkWriteDescriptorSet write{
+      VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,     // sType
+      nullptr,                                    // pNext
+      descriptor_set,                             // dstSet
+      0,                                          // dstbinding
+      0,                                          // dstArrayElement
+      1,                                          // descriptorCount
+      VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,  // descriptorType
+      &image_info,                                // pImageInfo
+      nullptr,                                    // pBufferInfo
+      nullptr,                                    // pTexelBufferView
+  };
 
-    app->device()->vkUpdateDescriptorSets(app->device(), 1, &write, 0, nullptr);
+  app->device()->vkUpdateDescriptorSets(app->device(), 1, &write, 0, nullptr);
 
-    return descriptor_set;
+  return descriptor_set;
 }
 
 containers::vector<vulkan::VkImageView> buildSamplerImageViews(
-    vulkan::VulkanApplication *app,
+    vulkan::VulkanApplication* app,
     const containers::vector<vulkan::ImagePointer>& images,
     const entry::EntryData* data) {
-    containers::vector<vulkan::VkImageView> image_views(data->allocator());
-    image_views.reserve(app->swapchain_images().size());
+  containers::vector<vulkan::VkImageView> image_views(data->allocator());
+  image_views.reserve(app->swapchain_images().size());
 
-    for(int index=0; index < images.size(); index++) {
-        auto sampler_image = images[index].get();
+  for (int index = 0; index < images.size(); index++) {
+    auto sampler_image = images[index].get();
 
-        VkImageViewCreateInfo image_view_create_info {
-            VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
-            nullptr,                                   // pNext
-            0,                                         // flags
-            sampler_image->get_raw_image(),            // image
-            VK_IMAGE_VIEW_TYPE_2D,                     // viewType
-            app->swapchain().format(),                 // format
-            {
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.r
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.g
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.b
-                VK_COMPONENT_SWIZZLE_IDENTITY,  // components.a
-            },
-            {
-                VK_IMAGE_ASPECT_COLOR_BIT,  // subresourceRange.aspectMask
-                0,                          // subresourceRange.baseMipLevel
-                1,                          // subresourceRange.levelCount
-                0,                          // subresourceRange.baseArrayLayer
-                1,                          // subresourceRange.layerCount
-            },
-        };
+    VkImageViewCreateInfo image_view_create_info{
+        VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
+        nullptr,                                   // pNext
+        0,                                         // flags
+        sampler_image->get_raw_image(),            // image
+        VK_IMAGE_VIEW_TYPE_2D,                     // viewType
+        app->swapchain().format(),                 // format
+        {
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.r
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.g
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.b
+            VK_COMPONENT_SWIZZLE_IDENTITY,  // components.a
+        },
+        {
+            VK_IMAGE_ASPECT_COLOR_BIT,  // subresourceRange.aspectMask
+            0,                          // subresourceRange.baseMipLevel
+            1,                          // subresourceRange.levelCount
+            0,                          // subresourceRange.baseArrayLayer
+            1,                          // subresourceRange.layerCount
+        },
+    };
 
-        VkImageView raw_image_view;
-        LOG_ASSERT(==, data->logger(), app->device()->vkCreateImageView(
-            app->device(),
-            &image_view_create_info,
-            nullptr,
-            &raw_image_view
-        ), VK_SUCCESS);
-        image_views.push_back(vulkan::VkImageView(raw_image_view, nullptr, &app->device()));
-    }
+    VkImageView raw_image_view;
+    LOG_ASSERT(
+        ==, data->logger(),
+        app->device()->vkCreateImageView(app->device(), &image_view_create_info,
+                                         nullptr, &raw_image_view),
+        VK_SUCCESS);
+    image_views.push_back(
+        vulkan::VkImageView(raw_image_view, nullptr, &app->device()));
+  }
 
-    return image_views;
+  return image_views;
 }
 
 containers::vector<vulkan::VkFramebuffer> buildFramebuffers(
-    vulkan::VulkanApplication *app,
-    const vulkan::VkRenderPass& render_pass,
+    vulkan::VulkanApplication* app, const vulkan::VkRenderPass& render_pass,
     const containers::vector<vulkan::VkImageView>& image_views,
     const entry::EntryData* data) {
-    containers::vector<vulkan::VkFramebuffer> framebuffers(data->allocator());
-    framebuffers.reserve(app->swapchain_images().size());
+  containers::vector<vulkan::VkFramebuffer> framebuffers(data->allocator());
+  framebuffers.reserve(app->swapchain_images().size());
 
-    for(int index=0; index < app->swapchain_images().size(); index++) {
-        VkFramebufferCreateInfo framebuffer_create_info {
-            VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,  // sType
-            nullptr,                                    // pNext
-            0,                                          // flags
-            render_pass,                                // renderPass
-            1,                                          // attachmentCount
-            &image_views[index].get_raw_object(),       // attachments
-            app->swapchain().width(),                   // width
-            app->swapchain().height(),                  // height
-            1                                           // layers
-        };
-
-        VkFramebuffer raw_framebuffer;
-        LOG_ASSERT(==, data->logger(), app->device()->vkCreateFramebuffer(
-            app->device(),
-            &framebuffer_create_info,
-            nullptr,
-            &raw_framebuffer
-        ), VK_SUCCESS);
-
-        framebuffers.push_back(vulkan::VkFramebuffer(raw_framebuffer, nullptr, &app->device()));
-    }
-
-    return framebuffers;
-}
-
-containers::unique_ptr<vulkan::VulkanApplication::Buffer> buildColorBuffer(vulkan::VulkanApplication *app) {
-    VkBufferCreateInfo create_info = {
-        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,  // sType
-        nullptr,                               // pNext
-        0,                                     // flags
-        COLOR_BUFFER_SIZE,                     // size
-        VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,  // usage
-        VK_SHARING_MODE_EXCLUSIVE,
-        0,
-        nullptr
+  for (int index = 0; index < app->swapchain_images().size(); index++) {
+    VkFramebufferCreateInfo framebuffer_create_info{
+        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,  // sType
+        nullptr,                                    // pNext
+        0,                                          // flags
+        render_pass,                                // renderPass
+        1,                                          // attachmentCount
+        &image_views[index].get_raw_object(),       // attachments
+        app->swapchain().width(),                   // width
+        app->swapchain().height(),                  // height
+        1                                           // layers
     };
 
-    return app->CreateAndBindDeviceBuffer(&create_info);
+    VkFramebuffer raw_framebuffer;
+    LOG_ASSERT(
+        ==, data->logger(),
+        app->device()->vkCreateFramebuffer(
+            app->device(), &framebuffer_create_info, nullptr, &raw_framebuffer),
+        VK_SUCCESS);
+
+    framebuffers.push_back(
+        vulkan::VkFramebuffer(raw_framebuffer, nullptr, &app->device()));
+  }
+
+  return framebuffers;
+}
+
+containers::unique_ptr<vulkan::VulkanApplication::Buffer> buildColorBuffer(
+    vulkan::VulkanApplication* app) {
+  VkBufferCreateInfo create_info = {
+      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,  // sType
+      nullptr,                               // pNext
+      0,                                     // flags
+      COLOR_BUFFER_SIZE,                     // size
+      VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,  // usage
+      VK_SHARING_MODE_EXCLUSIVE,
+      0,
+      nullptr};
+
+  return app->CreateAndBindDeviceBuffer(&create_info);
 }
 
 int main_entry(const entry::EntryData* data) {
-    data->logger()->LogInfo("Application Startup");
+  data->logger()->LogInfo("Application Startup");
 
-    // Enforce min_swapchain_image_count = 3
-    vulkan::VulkanApplication app(
-        data->allocator(), data->logger(), data, {}, {}, {0}, 
-        10 * 1024 * 1024,
-        512 * 1024 * 1024, 
-        10 * 1024 * 1024, 
-        1 * 1024 * 1024, false, false, false, 0, false,
-        false, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR, false, false, nullptr, false,
-        false, nullptr, 3);
+  // Enforce min_swapchain_image_count = 3
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions()
+                                    .SetHostBufferSize(10 * 1024 * 1024)
+                                    .SetDeviceImageSize(512 * 1024 * 1024)
+                                    .SetDeviceBufferSize(10 * 1024 * 1024)
+                                    .SetCoherentBufferSize(1 * 1024 * 1024)
+                                    .SetMinSwapchainImageCount(3),
+                                {}, {});
 
-    vulkan::VulkanModel screen(data->allocator(), data->logger(), screen_data);
+  vulkan::VulkanModel screen(data->allocator(), data->logger(), screen_data);
 
-    // Initialize Screen Model
-    auto init_cmd_buf = app.GetCommandBuffer();
-    app.BeginCommandBuffer(&init_cmd_buf);
+  // Initialize Screen Model
+  auto init_cmd_buf = app.GetCommandBuffer();
+  app.BeginCommandBuffer(&init_cmd_buf);
 
-    screen.InitializeData(&app, &init_cmd_buf);
-    vulkan::VkFence init_fence = CreateFence(&app.device());
-    app.EndAndSubmitCommandBuffer(
-        &init_cmd_buf,
-        &app.render_queue(),
-        {},
-        {},
-        {},
-        init_fence.get_raw_object()
-    );
+  screen.InitializeData(&app, &init_cmd_buf);
+  vulkan::VkFence init_fence = CreateFence(&app.device());
+  app.EndAndSubmitCommandBuffer(&init_cmd_buf, &app.render_queue(), {}, {}, {},
+                                init_fence.get_raw_object());
 
-    // Default Sampler
-    auto sampler = CreateDefaultSampler(&app.device());
+  // Default Sampler
+  auto sampler = CreateDefaultSampler(&app.device());
 
-    // Geometry Render Pass
-    auto g_render_pass = buildRenderPass(
-        &app,
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
-    );
-    auto g_pipeline = buildTrianglePipeline(&app, &g_render_pass);
-    
-    auto render_images = buildSamplerImages(&app, data);
-    auto render_image_views = buildSamplerImageViews(&app, render_images, data);
-    auto render_framebuffers = buildFramebuffers(&app, g_render_pass, render_image_views, data);
+  // Geometry Render Pass
+  auto g_render_pass =
+      buildRenderPass(&app, VK_IMAGE_LAYOUT_UNDEFINED,
+                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+  auto g_pipeline = buildTrianglePipeline(&app, &g_render_pass);
 
-    // Post Render Pass
-    auto post_render_pass = buildRenderPass(
-        &app,
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-    );
-    auto post_pipeline_layout = app.CreatePipelineLayout({{{
-        0,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+  auto render_images = buildSamplerImages(&app, data);
+  auto render_image_views = buildSamplerImageViews(&app, render_images, data);
+  auto render_framebuffers =
+      buildFramebuffers(&app, g_render_pass, render_image_views, data);
+
+  // Post Render Pass
+  auto post_render_pass = buildRenderPass(&app, VK_IMAGE_LAYOUT_UNDEFINED,
+                                          VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+  auto post_pipeline_layout =
+      app.CreatePipelineLayout({{{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                  1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}}});
+  auto post_pipeline = buildPostPipeline(&app, &post_pipeline_layout,
+                                         &post_render_pass, &screen);
+  auto post_image_views = buildSwapchainImageViews(&app, data);
+  auto post_framebuffers =
+      buildFramebuffers(&app, post_render_pass, post_image_views, data);
+
+  auto colorBuffer = buildColorBuffer(&app);
+
+  // FrameData
+  containers::vector<FrameData> frameData(data->allocator());
+  frameData.resize(app.swapchain_images().size());
+
+  for (int index = 0; index < app.swapchain_images().size(); index++) {
+    frameData[index].gCommandBuffer =
+        containers::make_unique<vulkan::VkCommandBuffer>(
+            data->allocator(), app.GetCommandBuffer());
+    frameData[index].postCommandBuffer =
+        containers::make_unique<vulkan::VkCommandBuffer>(
+            data->allocator(), app.GetCommandBuffer());
+    frameData[index].gRenderFinished =
+        containers::make_unique<vulkan::VkSemaphore>(
+            data->allocator(), vulkan::CreateSemaphore(&app.device()));
+    frameData[index].imageAcquired =
+        containers::make_unique<vulkan::VkSemaphore>(
+            data->allocator(), vulkan::CreateSemaphore(&app.device()));
+    frameData[index].postRenderFinished =
+        containers::make_unique<vulkan::VkSemaphore>(
+            data->allocator(), vulkan::CreateSemaphore(&app.device()));
+    frameData[index].renderingFence = containers::make_unique<vulkan::VkFence>(
+        data->allocator(), vulkan::CreateFence(&app.device(), true));
+    frameData[index].postProcessFence =
+        containers::make_unique<vulkan::VkFence>(
+            data->allocator(), vulkan::CreateFence(&app.device(), true));
+    frameData[index].descriptorSet =
+        containers::make_unique<vulkan::DescriptorSet>(
+            data->allocator(),
+            buildDescriptorSet(&app, sampler, render_image_views[index]));
+  }
+
+  uint32_t current_frame = 0;
+  uint32_t image_index;
+
+  VkClearValue clear_color = {0.40f, 0.94f, 0.59f, 1.0f};
+
+  // MAIN LOOP ======
+
+  while (!data->WindowClosing()) {
+    app.device()->vkAcquireNextImageKHR(
+        app.device(), app.swapchain().get_raw_object(), UINT64_MAX,
+        frameData[current_frame].imageAcquired->get_raw_object(),
+        static_cast<VkFence>(VK_NULL_HANDLE), &image_index);
+
+    const VkFence renderingFence =
+        frameData[current_frame].renderingFence->get_raw_object();
+    const VkFence postProcessFence =
+        frameData[current_frame].postProcessFence->get_raw_object();
+    VkFence currentFrameFences[] = {renderingFence, postProcessFence};
+
+    app.device()->vkWaitForFences(app.device(), 2, currentFrameFences, VK_FALSE,
+                                  UINT64_MAX);
+
+    if (app.device()->vkGetFenceStatus(app.device(), renderingFence) !=
+        VK_SUCCESS) {
+      app.device()->vkWaitForFences(app.device(), 1, &renderingFence, VK_TRUE,
+                                    UINT64_MAX);
+    }
+
+    app.device()->vkResetFences(app.device(), 1, &renderingFence);
+
+    auto& geometry_buf = frameData[image_index].gCommandBuffer;
+    auto& geo_ref = *geometry_buf;
+
+    app.BeginCommandBuffer(geometry_buf.get());
+
+    VkRenderPassBeginInfo g_pass_begin{
+        VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+        nullptr,
+        g_render_pass,
+        render_framebuffers[image_index].get_raw_object(),
+        {{0, 0}, {app.swapchain().width(), app.swapchain().height()}},
         1,
-        VK_SHADER_STAGE_FRAGMENT_BIT,
-        nullptr
-    }}});
-    auto post_pipeline = buildPostPipeline(&app, &post_pipeline_layout, &post_render_pass, &screen);
-    auto post_image_views = buildSwapchainImageViews(&app, data);
-    auto post_framebuffers = buildFramebuffers(
-        &app,
+        &clear_color};
+
+    geo_ref->vkCmdBeginRenderPass(geo_ref, &g_pass_begin,
+                                  VK_SUBPASS_CONTENTS_INLINE);
+    geo_ref->vkCmdBindPipeline(geo_ref, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                               g_pipeline);
+
+    VkDeviceSize offsets[] = {0};
+    VkBuffer vertexBuffers[1] = {*colorBuffer};
+    geo_ref->vkCmdBindVertexBuffers(geo_ref, 0, 1, vertexBuffers, offsets);
+    geo_ref->vkCmdDraw(geo_ref, 3, 1, 0, 0);
+    geo_ref->vkCmdEndRenderPass(geo_ref);
+    LOG_ASSERT(==, data->logger(), VK_SUCCESS,
+               app.EndAndSubmitCommandBuffer(
+                   geometry_buf.get(), &app.render_queue(),
+                   {frameData[current_frame].imageAcquired->get_raw_object()},
+                   {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT},
+                   {frameData[current_frame].gRenderFinished->get_raw_object()},
+                   renderingFence));
+
+    if (app.device()->vkGetFenceStatus(app.device(), postProcessFence) !=
+        VK_SUCCESS) {
+      app.device()->vkWaitForFences(app.device(), 1, &postProcessFence, VK_TRUE,
+                                    UINT64_MAX);
+    }
+
+    app.device()->vkResetFences(app.device(), 1, &postProcessFence);
+
+    VkRenderPassBeginInfo post_pass_begin{
+        VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+        nullptr,
         post_render_pass,
-        post_image_views,
-        data
-    );
+        post_framebuffers[image_index].get_raw_object(),
+        {{0, 0}, {app.swapchain().width(), app.swapchain().height()}},
+        1,
+        &clear_color};
 
-    auto colorBuffer = buildColorBuffer(&app);
+    auto& post_cmd_buf = frameData[image_index].postCommandBuffer;
+    vulkan::VkCommandBuffer& post_ref_cmd = *post_cmd_buf;
 
-    // FrameData
-    containers::vector<FrameData> frameData(data->allocator());
-    frameData.resize(app.swapchain_images().size());
+    app.BeginCommandBuffer(post_cmd_buf.get());
+    vulkan::RecordImageLayoutTransition(
+        app.swapchain_images()[image_index],
+        {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}, VK_IMAGE_LAYOUT_UNDEFINED, 0,
+        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, post_cmd_buf.get());
 
-    for(int index = 0; index < app.swapchain_images().size(); index++) {
-        frameData[index].gCommandBuffer = containers::make_unique<vulkan::VkCommandBuffer>(
-            data->allocator(),
-            app.GetCommandBuffer()
-        );
-        frameData[index].postCommandBuffer = containers::make_unique<vulkan::VkCommandBuffer>(
-            data->allocator(),
-            app.GetCommandBuffer()
-        );
-        frameData[index].gRenderFinished = containers::make_unique<vulkan::VkSemaphore>(
-            data->allocator(),
-            vulkan::CreateSemaphore(&app.device())
-        );
-        frameData[index].imageAcquired = containers::make_unique<vulkan::VkSemaphore>(
-            data->allocator(),
-            vulkan::CreateSemaphore(&app.device())
-        );
-        frameData[index].postRenderFinished = containers::make_unique<vulkan::VkSemaphore>(
-            data->allocator(),
-            vulkan::CreateSemaphore(&app.device())
-        );
-        frameData[index].renderingFence = containers::make_unique<vulkan::VkFence>(
-            data->allocator(),
-            vulkan::CreateFence(&app.device(), true)
-        );
-        frameData[index].postProcessFence = containers::make_unique<vulkan::VkFence>(
-            data->allocator(),
-            vulkan::CreateFence(&app.device(), true)
-        );
-        frameData[index].descriptorSet = containers::make_unique<vulkan::DescriptorSet>(
-            data->allocator(),
-            buildDescriptorSet(&app, sampler, render_image_views[index])
-        );
-    }
+    app.FillSmallBuffer(colorBuffer.get(),
+                        static_cast<const void*>(colors[current_frame % 3]),
+                        COLOR_BUFFER_SIZE, 0, &post_ref_cmd,
+                        VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT, 0);
 
-    uint32_t current_frame = 0;
-    uint32_t image_index;
+    post_ref_cmd->vkCmdBeginRenderPass(post_ref_cmd, &post_pass_begin,
+                                       VK_SUBPASS_CONTENTS_INLINE);
+    post_ref_cmd->vkCmdBindDescriptorSets(
+        post_ref_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, post_pipeline_layout, 0,
+        1, &frameData[image_index].descriptorSet->raw_set(), 0, nullptr);
+    post_ref_cmd->vkCmdBindPipeline(
+        post_ref_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, post_pipeline);
+    screen.Draw(&post_ref_cmd);
+    post_ref_cmd->vkCmdEndRenderPass(post_ref_cmd);
+    LOG_ASSERT(
+        ==, data->logger(), VK_SUCCESS,
+        app.EndAndSubmitCommandBuffer(
+            &post_ref_cmd, &app.render_queue(),
+            {frameData[current_frame].gRenderFinished->get_raw_object()},
+            {
+                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+            },
+            {frameData[current_frame]
+                 .postRenderFinished->get_raw_object()},  // postPass is done
+            postProcessFence                              // frame fence
+            ));
 
-    VkClearValue clear_color = {0.40f, 0.94f, 0.59f, 1.0f};
+    VkPresentInfoKHR present_info{
+        VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+        nullptr,
+        1,
+        &frameData[current_frame].postRenderFinished->get_raw_object(),
+        1,
+        &app.swapchain().get_raw_object(),
+        &image_index,
+        nullptr};
 
-    // MAIN LOOP ======
+    app.present_queue()->vkQueuePresentKHR(app.present_queue(), &present_info);
 
-    while(!data->WindowClosing()) {
-        app.device()->vkAcquireNextImageKHR(
-            app.device(),
-            app.swapchain().get_raw_object(),
-            UINT64_MAX,
-            frameData[current_frame].imageAcquired->get_raw_object(),
-            static_cast<VkFence>(VK_NULL_HANDLE),
-            &image_index
-        );
+    current_frame = (current_frame + 1) % app.swapchain_images().size();
+  }
 
-        const VkFence renderingFence = frameData[current_frame].renderingFence->get_raw_object();
-        const VkFence postProcessFence = frameData[current_frame].postProcessFence->get_raw_object();
-        VkFence currentFrameFences[] = {renderingFence, postProcessFence};
+  app.device()->vkDeviceWaitIdle(app.device());
+  data->logger()->LogInfo("Application Shutdown");
 
-        app.device()->vkWaitForFences(app.device(), 2, currentFrameFences, VK_FALSE, UINT64_MAX);
-
-        if (app.device()->vkGetFenceStatus(app.device(), renderingFence) != VK_SUCCESS) {
-            app.device()->vkWaitForFences(app.device(), 1, &renderingFence, VK_TRUE, UINT64_MAX);
-        }
-
-        app.device()->vkResetFences(app.device(), 1, &renderingFence);
-  
-        auto& geometry_buf = frameData[image_index].gCommandBuffer;
-        auto& geo_ref = *geometry_buf;
-
-        app.BeginCommandBuffer(geometry_buf.get());
-
-        VkRenderPassBeginInfo g_pass_begin {
-            VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-            nullptr,
-            g_render_pass,
-            render_framebuffers[image_index].get_raw_object(),
-            {{0, 0}, {app.swapchain().width(), app.swapchain().height()}},
-            1,
-            &clear_color
-        };
-
-        geo_ref->vkCmdBeginRenderPass(geo_ref, &g_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
-        geo_ref->vkCmdBindPipeline(geo_ref, VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipeline);
-
-        VkDeviceSize offsets[] = {0};
-        VkBuffer vertexBuffers[1] = {*colorBuffer};
-        geo_ref->vkCmdBindVertexBuffers(geo_ref, 0, 1, vertexBuffers, offsets);
-        geo_ref->vkCmdDraw(geo_ref, 3, 1, 0, 0);
-        geo_ref->vkCmdEndRenderPass(geo_ref);
-        LOG_ASSERT(==, data->logger(), VK_SUCCESS,
-            app.EndAndSubmitCommandBuffer(
-                geometry_buf.get(),
-                &app.render_queue(),
-                {frameData[current_frame].imageAcquired->get_raw_object()},
-                {
-                    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
-                },
-                {frameData[current_frame].gRenderFinished->get_raw_object()},
-                renderingFence
-            )
-        );
-
-        if (app.device()->vkGetFenceStatus(app.device(), postProcessFence) != VK_SUCCESS) {
-            app.device()->vkWaitForFences(app.device(), 1, &postProcessFence, VK_TRUE, UINT64_MAX);
-        }
-
-        app.device()->vkResetFences(app.device(), 1, &postProcessFence);
-
-        VkRenderPassBeginInfo post_pass_begin {
-            VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-            nullptr,
-            post_render_pass,
-            post_framebuffers[image_index].get_raw_object(),
-            {{0, 0}, {app.swapchain().width(), app.swapchain().height()}},
-            1,
-            &clear_color
-        };
-
-        auto& post_cmd_buf = frameData[image_index].postCommandBuffer;
-        vulkan::VkCommandBuffer& post_ref_cmd = *post_cmd_buf;
-
-        app.BeginCommandBuffer(post_cmd_buf.get());
-        vulkan::RecordImageLayoutTransition(
-            app.swapchain_images()[image_index],
-            {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-            VK_IMAGE_LAYOUT_UNDEFINED,
-            0,
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-            post_cmd_buf.get()
-        );
-
-        app.FillSmallBuffer(colorBuffer.get(), static_cast<const void*>(colors[current_frame % 3]),
-        COLOR_BUFFER_SIZE, 0, &post_ref_cmd, VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT, 0);
-
-        post_ref_cmd->vkCmdBeginRenderPass(post_ref_cmd, &post_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
-        post_ref_cmd->vkCmdBindDescriptorSets(
-            post_ref_cmd,
-            VK_PIPELINE_BIND_POINT_GRAPHICS,
-            post_pipeline_layout,
-            0,
-            1,
-            &frameData[image_index].descriptorSet->raw_set(),
-            0,
-            nullptr
-        );
-        post_ref_cmd->vkCmdBindPipeline(post_ref_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, post_pipeline);
-        screen.Draw(&post_ref_cmd);
-        post_ref_cmd->vkCmdEndRenderPass(post_ref_cmd);
-        LOG_ASSERT(==, data->logger(), VK_SUCCESS,
-            app.EndAndSubmitCommandBuffer(
-                &post_ref_cmd,
-                &app.render_queue(),
-                {frameData[current_frame].gRenderFinished->get_raw_object()},
-                {
-                   VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                },
-                {frameData[current_frame].postRenderFinished->get_raw_object()}, // postPass is done
-                postProcessFence // frame fence
-            )
-        );
-
-        VkPresentInfoKHR present_info {
-            VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
-            nullptr,
-            1,
-            &frameData[current_frame].postRenderFinished->get_raw_object(),
-            1,
-            &app.swapchain().get_raw_object(),
-            &image_index,
-            nullptr
-        };
-
-        app.present_queue()->vkQueuePresentKHR(app.present_queue(), &present_info);
-
-        current_frame = (current_frame + 1) % app.swapchain_images().size();
-    }
-
-    app.device()->vkDeviceWaitIdle(app.device());
-    data->logger()->LogInfo("Application Shutdown");
-
-    return 0;
+  return 0;
 }

--- a/gapid_tests/command_buffer_tests/BeginAndEndQuery_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/BeginAndEndQuery_test/main.cpp
@@ -33,7 +33,8 @@ uint32_t vertex_shader[] =
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
 
   {
@@ -66,7 +67,7 @@ int main_entry(const entry::EntryData* data) {
             nullptr                           // pPreserveAttachments
         }},                                   // SubpassDescriptions
         {}                                    // SubpassDependencies
-        );
+    );
 
     // Create shader modules.
 
@@ -223,10 +224,11 @@ int main_entry(const entry::EntryData* data) {
     };
 
     VkPipeline raw_pipeline;
-    LOG_EXPECT(==, data->logger(), device->vkCreateGraphicsPipelines(
-                                  device, app.pipeline_cache(), 1, &create_info,
-                                  nullptr, &raw_pipeline),
-               VK_SUCCESS);
+    LOG_EXPECT(
+        ==, data->logger(),
+        device->vkCreateGraphicsPipelines(device, app.pipeline_cache(), 1,
+                                          &create_info, nullptr, &raw_pipeline),
+        VK_SUCCESS);
     vulkan::VkPipeline pipeline(raw_pipeline, nullptr, &device);
 
     // Create image view.
@@ -253,10 +255,11 @@ int main_entry(const entry::EntryData* data) {
         },
     };
     ::VkImageView raw_image_view;
-    LOG_EXPECT(==, data->logger(), app.device()->vkCreateImageView(
-                                  app.device(), &image_view_create_info,
-                                  nullptr, &raw_image_view),
-               VK_SUCCESS);
+    LOG_EXPECT(
+        ==, data->logger(),
+        app.device()->vkCreateImageView(app.device(), &image_view_create_info,
+                                        nullptr, &raw_image_view),
+        VK_SUCCESS);
     vulkan::VkImageView image_view(raw_image_view, nullptr, &app.device());
 
     // Create framebuffer

--- a/gapid_tests/command_buffer_tests/BeginAndEndRenderPass_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/BeginAndEndRenderPass_test/main.cpp
@@ -19,8 +19,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data);
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        vulkan::VulkanApplicationOptions());
   {
     // 1. Render pass and framebuffer without attachments or dependencies. The
     // render pass begin info has render area with x/y offsets of value 5 and
@@ -146,9 +146,10 @@ int main_entry(const entry::EntryData* data) {
         },
     };
     ::VkImageView raw_image_view;
-    LOG_EXPECT(==, data->logger(), application.device()->vkCreateImageView(
-                                  application.device(), &image_view_create_info,
-                                  nullptr, &raw_image_view),
+    LOG_EXPECT(==, data->logger(),
+               application.device()->vkCreateImageView(
+                   application.device(), &image_view_create_info, nullptr,
+                   &raw_image_view),
                VK_SUCCESS);
     vulkan::VkImageView image_view(raw_image_view, nullptr,
                                    &application.device());

--- a/gapid_tests/command_buffer_tests/BufferImageCopy_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/BufferImageCopy_test/main.cpp
@@ -20,8 +20,10 @@ int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
   vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
-                                        {}, {}, {0}, 1024 * 100, 1024 * 100,
-                                        1024 * 100);
+                                        vulkan::VulkanApplicationOptions()
+                                            .SetHostBufferSize(1024 * 100)
+                                            .SetDeviceImageSize(1024 * 100)
+                                            .SetCoherentBufferSize(1024 * 100));
   VkImageCreateInfo image_create_info{
       /* sType = */ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
       /* pNext = */ nullptr,

--- a/gapid_tests/command_buffer_tests/DispatchAndDispatchIndirect_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/DispatchAndDispatchIndirect_test/main.cpp
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/helper_functions.h"
@@ -22,8 +24,6 @@
 #include "vulkan_wrapper/instance_wrapper.h"
 #include "vulkan_wrapper/library_wrapper.h"
 
-#include <algorithm>
-
 uint32_t compute_shader[] =
 #include "double_numbers.comp.spv"
     ;
@@ -31,7 +31,8 @@ uint32_t compute_shader[] =
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
 
   // Both input and output buffers have 512 32-bit integers.
@@ -62,8 +63,7 @@ int main_entry(const entry::EntryData* data) {
       nullptr,                            // pImmutableSamplers
   };
   auto compute_descriptor_set = containers::make_unique<vulkan::DescriptorSet>(
-      data->allocator(),
-      app.AllocateDescriptorSet({in_binding, out_binding}));
+      data->allocator(), app.AllocateDescriptorSet({in_binding, out_binding}));
 
   const VkDescriptorBufferInfo buffer_infos[2] = {
       {*in_buffer, 0, VK_WHOLE_SIZE}, {*out_buffer, 0, VK_WHOLE_SIZE}};

--- a/gapid_tests/command_buffer_tests/DrawCommands_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/DrawCommands_test/main.cpp
@@ -60,7 +60,8 @@ const uint32_t kIndex[] = {0, 1, 2};
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
 
   // Create vertex buffers and index buffer
@@ -104,7 +105,7 @@ int main_entry(const entry::EntryData* data) {
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   // Create pipeline
   vulkan::PipelineLayout pipeline_layout(app.CreatePipelineLayout({{}}));
@@ -160,10 +161,11 @@ int main_entry(const entry::EntryData* data) {
       },
   };
   ::VkImageView raw_image_view;
-  LOG_ASSERT(==, data->logger(), app.device()->vkCreateImageView(
-                                app.device(), &image_view_create_info, nullptr,
-                                &raw_image_view),
-             VK_SUCCESS);
+  LOG_ASSERT(
+      ==, data->logger(),
+      app.device()->vkCreateImageView(app.device(), &image_view_create_info,
+                                      nullptr, &raw_image_view),
+      VK_SUCCESS);
   vulkan::VkImageView image_view(raw_image_view, nullptr, &app.device());
 
   // Create framebuffer

--- a/gapid_tests/command_buffer_tests/SetDepthBias_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/SetDepthBias_test/main.cpp
@@ -139,7 +139,8 @@ int main_entry(const entry::EntryData* data) {
     const float depth_bias_slope_factor = 3.3f;
     // 1. Test with depthBiasClamp set to zero, so physical device feature:
     // depthBiasClamp is not required.
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                  vulkan::VulkanApplicationOptions());
     CreatePipelineAndSetDepthBias(data, &app, depth_bias_constant_factor,
                                   depth_bias_clamp, depth_bias_slope_factor);
   }
@@ -152,8 +153,9 @@ int main_entry(const entry::EntryData* data) {
     const float depth_bias_slope_factor = 3.3f;
     VkPhysicalDeviceFeatures request_features = {0};
     request_features.depthBiasClamp = VK_TRUE;
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
-                                  {}, request_features);
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                  vulkan::VulkanApplicationOptions(), {}, {},
+                                  request_features);
     if (app.device().is_valid()) {
       CreatePipelineAndSetDepthBias(data, &app, depth_bias_constant_factor,
                                     depth_bias_clamp, depth_bias_slope_factor);

--- a/gapid_tests/command_buffer_tests/SetLineWidthAndBlendConstants_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/SetLineWidthAndBlendConstants_test/main.cpp
@@ -96,7 +96,7 @@ vulkan::VulkanGraphicsPipeline CreateAndCommitPipeline(
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   vulkan::VulkanGraphicsPipeline pipeline =
       app.CreateGraphicsPipeline(&pipeline_layout, &render_pass, 0);
@@ -120,7 +120,8 @@ vulkan::VulkanGraphicsPipeline CreateAndCommitPipeline(
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
 
   {
     // 1. Test vkCmdBlendConstants

--- a/gapid_tests/command_buffer_tests/SetLineWidthAndBlendConstants_test/wide_lines.cpp
+++ b/gapid_tests/command_buffer_tests/SetLineWidthAndBlendConstants_test/wide_lines.cpp
@@ -125,8 +125,9 @@ int main_entry(const entry::EntryData* data) {
     const float line_width = 2.0;
     VkPhysicalDeviceFeatures requested_feateures{};
     requested_feateures.wideLines = VK_TRUE;
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
-                                  {}, requested_feateures);
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                  vulkan::VulkanApplicationOptions(), {}, {},
+                                  requested_feateures);
     if (app.device().is_valid()) {
       // Create a pipeline
       vulkan::VulkanGraphicsPipeline pipeline =

--- a/gapid_tests/command_buffer_tests/SetStencilMask_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/SetStencilMask_test/main.cpp
@@ -113,7 +113,8 @@ vulkan::VulkanGraphicsPipeline CreatePipeline(
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   auto pipeline = CreatePipeline(data, &app);
 
   {

--- a/gapid_tests/command_buffer_tests/SetViewportScissorAndBindPipeline_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/SetViewportScissorAndBindPipeline_test/main.cpp
@@ -32,7 +32,8 @@ uint32_t vertex_shader[] =
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
 
@@ -60,13 +61,13 @@ int main_entry(const entry::EntryData* data) {
 
     vulkan::VkRenderPass render_pass = app.CreateRenderPass(
         {{
-             0,                                                 // flags
-             VK_FORMAT_D32_SFLOAT,                              // format
-             VK_SAMPLE_COUNT_1_BIT,                             // samples
-             VK_ATTACHMENT_LOAD_OP_DONT_CARE,                   // loadOp
-             VK_ATTACHMENT_STORE_OP_STORE,                      // storeOp
-             VK_ATTACHMENT_LOAD_OP_DONT_CARE,                   // stencilLoadOp
-             VK_ATTACHMENT_STORE_OP_DONT_CARE,                  // stencilStoreOp
+             0,                                 // flags
+             VK_FORMAT_D32_SFLOAT,              // format
+             VK_SAMPLE_COUNT_1_BIT,             // samples
+             VK_ATTACHMENT_LOAD_OP_DONT_CARE,   // loadOp
+             VK_ATTACHMENT_STORE_OP_STORE,      // storeOp
+             VK_ATTACHMENT_LOAD_OP_DONT_CARE,   // stencilLoadOp
+             VK_ATTACHMENT_STORE_OP_DONT_CARE,  // stencilStoreOp
              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,  // initialLayout
              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL   // finalLayout
          },
@@ -94,7 +95,7 @@ int main_entry(const entry::EntryData* data) {
             nullptr                           // pPreserveAttachments
         }},                                   // SubpassDescriptions
         {}                                    // SubpassDependencies
-        );
+    );
 
     vulkan::VulkanGraphicsPipeline pipeline =
         app.CreateGraphicsPipeline(&pipeline_layout, &render_pass, 0);

--- a/gapid_tests/command_buffer_tests/vkCmdBindDescriptorSets_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdBindDescriptorSets_test/main.cpp
@@ -19,7 +19,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
 
   vulkan::VkCommandBuffer command_buffer = app.GetCommandBuffer();

--- a/gapid_tests/command_buffer_tests/vkCmdBindIndexBuffer_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdBindIndexBuffer_test/main.cpp
@@ -24,7 +24,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
 

--- a/gapid_tests/command_buffer_tests/vkCmdBindVertexBuffers_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdBindVertexBuffers_test/main.cpp
@@ -24,7 +24,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
 

--- a/gapid_tests/command_buffer_tests/vkCmdBlitImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdBlitImage_test/main.cpp
@@ -25,8 +25,10 @@ int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
   vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
-                                        {}, {}, {0}, 1024 * 100, 1024 * 100,
-                                        1024 * 100);
+                                        vulkan::VulkanApplicationOptions()
+                                            .SetHostBufferSize(1024 * 100)
+                                            .SetDeviceImageSize(1024 * 100)
+                                            .SetCoherentBufferSize(1024 * 100));
 
   VkExtent3D src_image_extent{32, 32, 1};
   VkImageCreateInfo image_create_info{

--- a/gapid_tests/command_buffer_tests/vkCmdClearAttachments_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdClearAttachments_test/main.cpp
@@ -25,8 +25,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data);
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = application.device();
 
   {

--- a/gapid_tests/command_buffer_tests/vkCmdClearColorImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdClearColorImage_test/main.cpp
@@ -22,7 +22,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   {
     // 1. Clear a 2D single layer, single mip level color image

--- a/gapid_tests/command_buffer_tests/vkCmdClearDepthStencilImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdClearDepthStencilImage_test/main.cpp
@@ -13,17 +13,18 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_wrapper/sub_objects.h"
 
-#include <algorithm>
-
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   {
     // 1. Clear a 2D single layer, single mip level depth/stencil image
@@ -94,7 +95,7 @@ int main_entry(const entry::EntryData* data) {
         &clear_depth_stencil,                  // pDepthStencil
         1,                                     // rangeCount
         &clear_range                           // pRagnes
-        );
+    );
     cmd_buf->vkEndCommandBuffer(cmd_buf);
     VkSubmitInfo submit_info{VK_STRUCTURE_TYPE_SUBMIT_INFO,
                              nullptr,

--- a/gapid_tests/command_buffer_tests/vkCmdCopyImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdCopyImage_test/main.cpp
@@ -57,9 +57,12 @@ int main_entry(const entry::EntryData* data) {
     // 1. Copy from an uncompressed 2D color image, with only 1 layer, 1
     // miplevel and 0 offsets in all dimensions to another 2D image created
     // with same create info.
-    vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                          data, {}, {}, {0}, 1024 * 100,
-                                          1024 * 100, 1024 * 100);
+    vulkan::VulkanApplication application(
+        data->allocator(), data->logger(), data,
+        vulkan::VulkanApplicationOptions()
+            .SetHostBufferSize(1024 * 100)
+            .SetDeviceImageSize(1024 * 100)
+            .SetCoherentBufferSize(1024 * 100));
     vulkan::VkDevice& device = application.device();
 
     vulkan::ImagePointer src_image =
@@ -188,9 +191,13 @@ int main_entry(const entry::EntryData* data) {
     // dimensions but in BC3 format.
     VkPhysicalDeviceFeatures requested_features = {0};
     requested_features.textureCompressionBC = VK_TRUE;
-    vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                          data, {}, {}, requested_features,
-                                          1024 * 100, 1024 * 100, 1024 * 100);
+    vulkan::VulkanApplication application(
+        data->allocator(), data->logger(), data,
+        vulkan::VulkanApplicationOptions()
+            .SetHostBufferSize(1024 * 100)
+            .SetDeviceImageSize(1024 * 100)
+            .SetCoherentBufferSize(1024 * 100),
+        {}, {}, requested_features);
     vulkan::VkDevice& device = application.device();
     if (device.is_valid()) {
       VkImageCreateInfo src_image_create_info = sample_image_create_info;

--- a/gapid_tests/command_buffer_tests/vkCmdCopyQueryPoolResults_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdCopyQueryPoolResults_test/main.cpp
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+#include <utility>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/helper_functions.h"
@@ -21,9 +24,6 @@
 #include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_wrapper/instance_wrapper.h"
 #include "vulkan_wrapper/library_wrapper.h"
-
-#include <algorithm>
-#include <utility>
 
 uint32_t fragment_shader[] =
 #include "hardcode_pos_triangle.frag.spv"
@@ -69,7 +69,7 @@ void QueryWithoutDrawingAnythingAndCopyResults(
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   // Create shader modules.
   vulkan::VkShaderModule vertex_shader_module =
@@ -221,10 +221,11 @@ void QueryWithoutDrawingAnythingAndCopyResults(
   };
 
   VkPipeline raw_pipeline;
-  LOG_EXPECT(==, data->logger(), device->vkCreateGraphicsPipelines(
-                                device, app->pipeline_cache(), 1, &create_info,
-                                nullptr, &raw_pipeline),
-             VK_SUCCESS);
+  LOG_EXPECT(
+      ==, data->logger(),
+      device->vkCreateGraphicsPipelines(device, app->pipeline_cache(), 1,
+                                        &create_info, nullptr, &raw_pipeline),
+      VK_SUCCESS);
   vulkan::VkPipeline pipeline(raw_pipeline, nullptr, &device);
 
   // Create image view.
@@ -250,10 +251,11 @@ void QueryWithoutDrawingAnythingAndCopyResults(
       },
   };
   ::VkImageView raw_image_view;
-  LOG_EXPECT(==, data->logger(), app->device()->vkCreateImageView(
-                                app->device(), &image_view_create_info, nullptr,
-                                &raw_image_view),
-             VK_SUCCESS);
+  LOG_EXPECT(
+      ==, data->logger(),
+      app->device()->vkCreateImageView(app->device(), &image_view_create_info,
+                                       nullptr, &raw_image_view),
+      VK_SUCCESS);
   vulkan::VkImageView image_view(raw_image_view, nullptr, &app->device());
 
   // Create framebuffer
@@ -344,7 +346,7 @@ void QueryWithoutDrawingAnythingAndCopyResults(
       &to_dst_barrier,                 // pBufferMemoryBarriers
       0,                               // imageMemoryBarrierCount
       nullptr                          // pImageMemoryBarriers
-      );
+  );
 
   // Call vkCmdCopyQueryPoolResults
   command_buffer->vkCmdCopyQueryPoolResults(
@@ -387,12 +389,13 @@ vulkan::BufferPointer CreateBufferAndFlush(vulkan::VulkanApplication* app,
   buffer->flush();
   return std::move(buffer);
 }
-}
+}  // namespace
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
 
   {
     // 1. Get 32-bit results from all the queries in a four-query pool,
@@ -408,19 +411,20 @@ int main_entry(const entry::EntryData* data) {
         CreateBufferAndFlush(&app, buffer_size, 0xff);
 
     QueryWithoutDrawingAnythingAndCopyResults(
-        data, &app, {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
-                     VK_QUERY_TYPE_OCCLUSION, num_queries, 0},
+        data, &app,
+        {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
+         VK_QUERY_TYPE_OCCLUSION, num_queries, 0},
         first_query, num_queries, *result_buffer, offset, stride, flags);
 
     result_buffer->invalidate();
 
     for (uint32_t i = 0; i < buffer_size; i++) {
       if (i < offset) {
-        LOG_ASSERT(==, data->logger(), uint8_t(result_buffer->base_address()[i]),
-                   0xFFU);
+        LOG_ASSERT(==, data->logger(),
+                   uint8_t(result_buffer->base_address()[i]), 0xFFU);
       } else {
-        LOG_ASSERT(==, data->logger(), uint8_t(result_buffer->base_address()[i]),
-                   0x0U);
+        LOG_ASSERT(==, data->logger(),
+                   uint8_t(result_buffer->base_address()[i]), 0x0U);
       }
     }
   }
@@ -442,8 +446,9 @@ int main_entry(const entry::EntryData* data) {
         CreateBufferAndFlush(&app, buffer_size, 0xff);
 
     QueryWithoutDrawingAnythingAndCopyResults(
-        data, &app, {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
-                     VK_QUERY_TYPE_OCCLUSION, total_num_queries, 0},
+        data, &app,
+        {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
+         VK_QUERY_TYPE_OCCLUSION, total_num_queries, 0},
         first_query, num_queries, *result_buffer, offset, stride, flags);
 
     result_buffer->invalidate();
@@ -471,8 +476,9 @@ int main_entry(const entry::EntryData* data) {
         CreateBufferAndFlush(&app, buffer_size, 0xff);
 
     QueryWithoutDrawingAnythingAndCopyResults(
-        data, &app, {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
-                     VK_QUERY_TYPE_OCCLUSION, num_queries, 0},
+        data, &app,
+        {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
+         VK_QUERY_TYPE_OCCLUSION, num_queries, 0},
         first_query, num_queries, *result_buffer, offset, stride, flags);
 
     result_buffer->invalidate();

--- a/gapid_tests/command_buffer_tests/vkCmdExecuteCommands_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdExecuteCommands_test/main.cpp
@@ -25,7 +25,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   containers::vector<char> pseudo_data(16, 0xba, data->allocator());
 
@@ -114,10 +115,11 @@ int main_entry(const entry::EntryData* data) {
     VkSubmitInfo submit{
         VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 0,      nullptr, nullptr, 1,
         &raw_primary_cmd_buf,          0,       nullptr};
-    LOG_ASSERT(==, data->logger(), app.render_queue()->vkQueueSubmit(
-                                  app.render_queue(), 1, &submit,
-                                  static_cast<VkFence>(VK_NULL_HANDLE)),
-               VK_SUCCESS);
+    LOG_ASSERT(
+        ==, data->logger(),
+        app.render_queue()->vkQueueSubmit(app.render_queue(), 1, &submit,
+                                          static_cast<VkFence>(VK_NULL_HANDLE)),
+        VK_SUCCESS);
     LOG_ASSERT(==, data->logger(),
                app.render_queue()->vkQueueWaitIdle(app.render_queue()),
                VK_SUCCESS);

--- a/gapid_tests/command_buffer_tests/vkCmdFillBuffer_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdFillBuffer_test/main.cpp
@@ -13,17 +13,17 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/vulkan_application.h"
 
-#include <algorithm>
-
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data);
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        vulkan::VulkanApplicationOptions());
   {
     // Fill a buffer first with data: 0x12345678, size: VK_WHOLE_SIZE and
     // offset: 0, then fill it again with data: 0xabcdabcd, size: 256 and
@@ -56,7 +56,7 @@ int main_entry(const entry::EntryData* data) {
                              0,               // dstOffset
                              VK_WHOLE_SIZE,   // size
                              first_fill_uint  // pData
-                             );
+    );
 
     VkBufferMemoryBarrier dst_to_src_barrier{
         VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,  // sType
@@ -80,7 +80,7 @@ int main_entry(const entry::EntryData* data) {
         &dst_to_src_barrier,             // pBufferMemoryBarriers
         0,                               // imageMemoryBarrierCount
         nullptr                          // pImageMemoryBarriers
-        );
+    );
 
     cmd_buf->vkEndCommandBuffer(cmd_buf);
     VkCommandBuffer raw_cmd_buf = cmd_buf.get_command_buffer();
@@ -116,7 +116,7 @@ int main_entry(const entry::EntryData* data) {
                              fill_offset,      // dstOffset
                              fill_size,        // size
                              second_fill_uint  // pData
-                             );
+    );
     cmd_buf->vkCmdPipelineBarrier(
         cmd_buf,                         // commandBuffer
         VK_PIPELINE_STAGE_HOST_BIT,      // srcStageMask
@@ -128,7 +128,7 @@ int main_entry(const entry::EntryData* data) {
         &dst_to_src_barrier,             // pBufferMemoryBarriers
         0,                               // imageMemoryBarrierCount
         nullptr                          // pImageMemoryBarriers
-        );
+    );
     cmd_buf->vkEndCommandBuffer(cmd_buf);
     application.render_queue()->vkQueueSubmit(
         application.render_queue(), 1, &submit,

--- a/gapid_tests/command_buffer_tests/vkCmdNextSubpass_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdNextSubpass_test/main.cpp
@@ -99,8 +99,9 @@ int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
   vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
-                                {}, {}, {0},
-                                1024*1024, 100*1024*1024);
+                                vulkan::VulkanApplicationOptions()
+                                    .SetHostBufferSize(1024 * 1024)
+                                    .SetDeviceImageSize(1024 * 1024 * 100));
   vulkan::VkDevice& device = app.device();
 
   auto fence = vulkan::CreateFence(&app.device(), false);

--- a/gapid_tests/command_buffer_tests/vkCmdPushConstants_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdPushConstants_test/main.cpp
@@ -25,13 +25,13 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1,
                                        VK_SHADER_STAGE_VERTEX_BIT, nullptr};
   vulkan::VkDescriptorSetLayout descriptor_set_layout =
-      vulkan::CreateDescriptorSetLayout(data->allocator(), &device,
-                                        {binding});
+      vulkan::CreateDescriptorSetLayout(data->allocator(), &device, {binding});
 
   // The size of the data must be a multiple of 4
   containers::vector<char> constants(100, 0xab, data->allocator());

--- a/gapid_tests/command_buffer_tests/vkCmdResetQueryPool_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdResetQueryPool_test/main.cpp
@@ -13,17 +13,18 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_wrapper/sub_objects.h"
 
-#include <algorithm>
-
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   {
     // Creates one query pool with 4 queries, another one with 7 queries, then
@@ -60,12 +61,12 @@ int main_entry(const entry::EntryData* data) {
                                  four_queries_pool,  // queryPool
                                  0,                  // firstQuery
                                  4                   // queryCount
-                                 );
+    );
     cmd_buf->vkCmdResetQueryPool(cmd_buf,             // commandBuffer
                                  seven_queries_pool,  // queryPool
                                  1,                   // firstQuery
                                  5                    // queryCount
-                                 );
+    );
     cmd_buf->vkEndCommandBuffer(cmd_buf);
     VkSubmitInfo submit_info{VK_STRUCTURE_TYPE_SUBMIT_INFO,
                              nullptr,

--- a/gapid_tests/command_buffer_tests/vkCmdResolveImage_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdResolveImage_test/main.cpp
@@ -23,7 +23,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication application(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        vulkan::VulkanApplicationOptions());
 
   const VkExtent3D sample_image_extent{32, 32, 1};
   const VkImageCreateInfo sample_image_create_info{

--- a/gapid_tests/command_buffer_tests/vkCmdSetDepthBounds_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdSetDepthBounds_test/main.cpp
@@ -121,8 +121,9 @@ int main_entry(const entry::EntryData* data) {
     VkPhysicalDeviceFeatures request_features = {0};
     request_features.depthBounds = VK_TRUE;
 
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
-                                  {}, request_features);
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                  vulkan::VulkanApplicationOptions(), {}, {},
+                                  request_features);
     if (app.device().is_valid()) {
       auto pipeline = CreatePipelineWithDepthBoundTestEnabled(data, &app);
       auto cmdBuf = app.GetCommandBuffer();

--- a/gapid_tests/command_buffer_tests/vkCmdSetStencilReference_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdSetStencilReference_test/main.cpp
@@ -90,7 +90,7 @@ vulkan::VulkanGraphicsPipeline CreatePipeline(
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   vulkan::VulkanGraphicsPipeline pipeline =
       app.CreateGraphicsPipeline(&pipeline_layout, &render_pass, 0);
@@ -112,18 +112,22 @@ vulkan::VulkanGraphicsPipeline CreatePipeline(
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   auto pipeline = CreatePipeline(data, &app);
 
   {
     // Test vkCmdSetStencilReference
-    vulkan::VkCommandBuffer cmd_buf= app.GetCommandBuffer();
+    vulkan::VkCommandBuffer cmd_buf = app.GetCommandBuffer();
     app.BeginCommandBuffer(&cmd_buf);
-    cmd_buf->vkCmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    cmd_buf->vkCmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                               pipeline);
     cmd_buf->vkCmdSetStencilReference(cmd_buf, VK_STENCIL_FACE_FRONT_BIT, 0u);
     cmd_buf->vkCmdSetStencilReference(cmd_buf, VK_STENCIL_FACE_BACK_BIT, 10u);
-    cmd_buf->vkCmdSetStencilReference(cmd_buf, VK_STENCIL_FRONT_AND_BACK, 0xFFFFFFFFU);
-    app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf, &app.render_queue());
+    cmd_buf->vkCmdSetStencilReference(cmd_buf, VK_STENCIL_FRONT_AND_BACK,
+                                      0xFFFFFFFFU);
+    app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf,
+                                                     &app.render_queue());
   }
 
   data->logger()->LogInfo("Application Shutdown");

--- a/gapid_tests/command_buffer_tests/vkCmdUpdateBuffer_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdUpdateBuffer_test/main.cpp
@@ -13,18 +13,20 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/vulkan_application.h"
-
-#include <algorithm>
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
   vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
-                                        {}, {}, {0}, 1024 * 100, 1024 * 100,
-                                        1024 * 100);
+                                        vulkan::VulkanApplicationOptions()
+                                            .SetHostBufferSize(1024 * 100)
+                                            .SetDeviceImageSize(1024 * 100)
+                                            .SetCoherentBufferSize(1024 * 100));
   {
     // Update a buffer with size 65536 bytes and 0 offset.
     size_t update_size = 65536;

--- a/gapid_tests/command_buffer_tests/vkCmdWriteTimestamp_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkCmdWriteTimestamp_test/main.cpp
@@ -60,7 +60,8 @@ const uint32_t kIndex[] = {0, 1, 2};
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   uint32_t queue_family_index = app.render_queue().index();
   auto queue_family_properties = vulkan::GetQueueFamilyProperties(
@@ -114,7 +115,7 @@ int main_entry(const entry::EntryData* data) {
             nullptr                           // pPreserveAttachments
         }},                                   // SubpassDescriptions
         {}                                    // SubpassDependencies
-        );
+    );
 
     // Create pipeline
     vulkan::PipelineLayout pipeline_layout(app.CreatePipelineLayout({{}}));
@@ -170,10 +171,11 @@ int main_entry(const entry::EntryData* data) {
         },
     };
     ::VkImageView raw_image_view;
-    LOG_ASSERT(==, data->logger(), app.device()->vkCreateImageView(
-                                  app.device(), &image_view_create_info,
-                                  nullptr, &raw_image_view),
-               VK_SUCCESS);
+    LOG_ASSERT(
+        ==, data->logger(),
+        app.device()->vkCreateImageView(app.device(), &image_view_create_info,
+                                        nullptr, &raw_image_view),
+        VK_SUCCESS);
     vulkan::VkImageView image_view(raw_image_view, nullptr, &app.device());
 
     // Create framebuffer
@@ -251,10 +253,10 @@ int main_entry(const entry::EntryData* data) {
           reinterpret_cast<void*>(time_stamps), sizeof(uint64_t),
           VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
       data->logger()->LogInfo("    Vertex shader timestamp for vkCmdDraw: ",
-                         time_stamps[0]);
+                              time_stamps[0]);
       LOG_ASSERT(!=, data->logger(), 0, time_stamps[0]);
       data->logger()->LogInfo("    Fragment shader timestamp for vkCmdDraw: ",
-                         time_stamps[1]);
+                              time_stamps[1]);
       LOG_ASSERT(!=, data->logger(), 0, time_stamps[1]);
     }
 
@@ -304,11 +306,12 @@ int main_entry(const entry::EntryData* data) {
           device, query_pool, 0, 2, sizeof(time_stamps),
           reinterpret_cast<void*>(time_stamps), sizeof(uint64_t),
           VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
-      data->logger()->LogInfo("    Vertex shader timestamp for vkCmdDrawIndexed: ",
-                         time_stamps[0]);
+      data->logger()->LogInfo(
+          "    Vertex shader timestamp for vkCmdDrawIndexed: ", time_stamps[0]);
       LOG_ASSERT(!=, data->logger(), 0, time_stamps[0]);
-      data->logger()->LogInfo("    Fragment shader timestamp for vkCmdDrawIndexed: ",
-                         time_stamps[1]);
+      data->logger()->LogInfo(
+          "    Fragment shader timestamp for vkCmdDrawIndexed: ",
+          time_stamps[1]);
       LOG_ASSERT(!=, data->logger(), 0, time_stamps[1]);
     }
   }

--- a/gapid_tests/command_buffer_tests/vkQueuePresentKHR_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkQueuePresentKHR_test/main.cpp
@@ -22,7 +22,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   {
     // 1. Present a queue with no semaphore and result array, but one swapchain.
@@ -56,7 +57,8 @@ int main_entry(const entry::EntryData* data) {
         VK_IMAGE_LAYOUT_UNDEFINED, static_cast<VkAccessFlags>(0u),
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT,
         &cmd_buf);
-    app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf, &app.present_queue());
+    app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf,
+                                                     &app.present_queue());
 
     VkCommandBufferBeginInfo info{
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,  // sType
@@ -106,8 +108,8 @@ int main_entry(const entry::EntryData* data) {
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT,
         VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, static_cast<VkAccessFlags>(0u),
         &cmd_buf);
-    app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf, &app.present_queue());
-
+    app.EndAndSubmitCommandBufferAndWaitForQueueIdle(&cmd_buf,
+                                                     &app.present_queue());
 
     // Call vkQueuePresentKHR()
     ::VkSwapchainKHR raw_swapchain = app.swapchain().get_raw_object();
@@ -121,8 +123,9 @@ int main_entry(const entry::EntryData* data) {
         &image_index,                        // pImageIndices
         nullptr,                             // pResults
     };
-    LOG_ASSERT(==, data->logger(), app.present_queue()->vkQueuePresentKHR(
-                                  app.present_queue(), &present_info),
+    LOG_ASSERT(==, data->logger(),
+               app.present_queue()->vkQueuePresentKHR(app.present_queue(),
+                                                      &present_info),
                VK_SUCCESS);
   }
 

--- a/gapid_tests/command_buffer_tests/vkTrimCommandPool_test/main.cpp
+++ b/gapid_tests/command_buffer_tests/vkTrimCommandPool_test/main.cpp
@@ -25,15 +25,14 @@ int main_entry(const entry::EntryData* data) {
   vulkan::LibraryWrapper wrapper(data->allocator(), data->logger());
   vulkan::VkInstance instance(
       // vkTrimCommandPool should only be called with VK version 1.1 and greater
-      vulkan::CreateEmptyInstance(data->allocator(), &wrapper, VK_MAKE_VERSION(1, 1, 0)));
+      vulkan::CreateEmptyInstance(data->allocator(), &wrapper,
+                                  VK_MAKE_VERSION(1, 1, 0)));
   vulkan::VkDevice device(
       vulkan::CreateDefaultDevice(data->allocator(), instance));
   vulkan::VkCommandPool pool(
       vulkan::CreateDefaultCommandPool(data->allocator(), device, false));
 
-  {
-    device->vkTrimCommandPool(device, pool, 0);
-  }
+  { device->vkTrimCommandPool(device, pool, 0); }
 
   data->logger()->LogInfo("Application Shutdown");
   return 0;

--- a/gapid_tests/resource_acquisition_tests/vkAcquireNextImageKHR_test/main.cpp
+++ b/gapid_tests/resource_acquisition_tests/vkAcquireNextImageKHR_test/main.cpp
@@ -19,7 +19,8 @@
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   {
     // 1. Acquire the next image with one semaphore but no fence

--- a/gapid_tests/resource_acquisition_tests/vkGetImageSubresourceLayout_test/main.cpp
+++ b/gapid_tests/resource_acquisition_tests/vkGetImageSubresourceLayout_test/main.cpp
@@ -21,7 +21,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
 
   const VkImageType type = VK_IMAGE_TYPE_2D;
@@ -32,7 +33,7 @@ int main_entry(const entry::EntryData* data) {
       VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
   uint32_t width = 32;
   uint32_t height = 32;
-  uint32_t depth = 1; // becaue of 2D image
+  uint32_t depth = 1;  // becaue of 2D image
   uint32_t mip_level = 6;
   uint32_t array_layer = 3;
 
@@ -121,8 +122,10 @@ int main_entry(const entry::EntryData* data) {
     data->logger()->LogInfo("\tSubresourceLayout.offset: ", layout.offset);
     data->logger()->LogInfo("\tSubresourceLayout.size: ", layout.size);
     data->logger()->LogInfo("\tSubresourceLayout.rowPitch: ", layout.rowPitch);
-    data->logger()->LogInfo("\tSubresourceLayout.arrayPitch: ", layout.arrayPitch);
-    data->logger()->LogInfo("\tSubresourceLayout.depthPitch: ", layout.depthPitch);
+    data->logger()->LogInfo("\tSubresourceLayout.arrayPitch: ",
+                            layout.arrayPitch);
+    data->logger()->LogInfo("\tSubresourceLayout.depthPitch: ",
+                            layout.depthPitch);
 
     // offset, must be within the valid range.
     LOG_EXPECT(<=, data->logger(), layout.offset + layout.size, req.size);

--- a/gapid_tests/resource_acquisition_tests/vkGetPipelineCacheData_test/main.cpp
+++ b/gapid_tests/resource_acquisition_tests/vkGetPipelineCacheData_test/main.cpp
@@ -32,7 +32,8 @@ uint32_t vertex_shader[] =
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
 
   {
     vulkan::VkDevice& device = app.device();
@@ -105,13 +106,13 @@ int main_entry(const entry::EntryData* data) {
 
     vulkan::VkRenderPass render_pass = app.CreateRenderPass(
         {{
-             0,                                                 // flags
-             VK_FORMAT_D32_SFLOAT,                              // format
-             VK_SAMPLE_COUNT_1_BIT,                             // samples
-             VK_ATTACHMENT_LOAD_OP_DONT_CARE,                   // loadOp
-             VK_ATTACHMENT_STORE_OP_STORE,                      // storeOp
-             VK_ATTACHMENT_LOAD_OP_DONT_CARE,                   // stencilLoadOp
-             VK_ATTACHMENT_STORE_OP_DONT_CARE,                  // stencilStoreOp
+             0,                                 // flags
+             VK_FORMAT_D32_SFLOAT,              // format
+             VK_SAMPLE_COUNT_1_BIT,             // samples
+             VK_ATTACHMENT_LOAD_OP_DONT_CARE,   // loadOp
+             VK_ATTACHMENT_STORE_OP_STORE,      // storeOp
+             VK_ATTACHMENT_LOAD_OP_DONT_CARE,   // stencilLoadOp
+             VK_ATTACHMENT_STORE_OP_DONT_CARE,  // stencilStoreOp
              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,  // initialLayout
              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL   // finalLayout
          },
@@ -139,7 +140,7 @@ int main_entry(const entry::EntryData* data) {
             nullptr                           // pPreserveAttachments
         }},                                   // SubpassDescriptions
         {}                                    // SubpassDependencies
-        );
+    );
 
     // Create shader modules
     vulkan::VkShaderModule vertex_shader_module =

--- a/gapid_tests/resource_acquisition_tests/vkGetQueryPoolResults_test/main.cpp
+++ b/gapid_tests/resource_acquisition_tests/vkGetQueryPoolResults_test/main.cpp
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+#include <array>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/helper_functions.h"
@@ -21,9 +24,6 @@
 #include "vulkan_helpers/vulkan_application.h"
 #include "vulkan_wrapper/instance_wrapper.h"
 #include "vulkan_wrapper/library_wrapper.h"
-
-#include <algorithm>
-#include <array>
 
 uint32_t fragment_shader[] =
 #include "hardcode_pos_triangle.frag.spv"
@@ -67,7 +67,7 @@ vulkan::VkQueryPool QueryWithoutDrawingAnything(
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
 
   // Create shader modules.
   vulkan::VkShaderModule vertex_shader_module =
@@ -219,10 +219,11 @@ vulkan::VkQueryPool QueryWithoutDrawingAnything(
   };
 
   VkPipeline raw_pipeline;
-  LOG_EXPECT(==, data->logger(), device->vkCreateGraphicsPipelines(
-                                device, app->pipeline_cache(), 1, &create_info,
-                                nullptr, &raw_pipeline),
-             VK_SUCCESS);
+  LOG_EXPECT(
+      ==, data->logger(),
+      device->vkCreateGraphicsPipelines(device, app->pipeline_cache(), 1,
+                                        &create_info, nullptr, &raw_pipeline),
+      VK_SUCCESS);
   vulkan::VkPipeline pipeline(raw_pipeline, nullptr, &device);
 
   // Create image view.
@@ -248,10 +249,11 @@ vulkan::VkQueryPool QueryWithoutDrawingAnything(
       },
   };
   ::VkImageView raw_image_view;
-  LOG_EXPECT(==, data->logger(), app->device()->vkCreateImageView(
-                                app->device(), &image_view_create_info, nullptr,
-                                &raw_image_view),
-             VK_SUCCESS);
+  LOG_EXPECT(
+      ==, data->logger(),
+      app->device()->vkCreateImageView(app->device(), &image_view_create_info,
+                                       nullptr, &raw_image_view),
+      VK_SUCCESS);
   vulkan::VkImageView image_view(raw_image_view, nullptr, &app->device());
 
   // Create framebuffer
@@ -337,20 +339,22 @@ vulkan::VkQueryPool QueryWithoutDrawingAnything(
 
   return query_pool;
 }
-}
+}  // namespace
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
 
   {
     // 1. Get 32-bit results from all the queries in a four-query pool,
     // without any result flag
     const uint32_t num_queries = 4;
     vulkan::VkQueryPool query_pool = QueryWithoutDrawingAnything(
-        data, &app, {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
-                     VK_QUERY_TYPE_OCCLUSION, num_queries, 0});
+        data, &app,
+        {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
+         VK_QUERY_TYPE_OCCLUSION, num_queries, 0});
 
     std::array<uint32_t, num_queries> query_results{0xFFFFFFFF, 0xFFFFFFFF,
                                                     0xFFFFFFFF, 0xFFFFFFFF};
@@ -368,9 +372,10 @@ int main_entry(const entry::EntryData* data) {
                    ),
                VK_SUCCESS);
 
-    std::for_each(
-        std::begin(query_results), std::end(query_results),
-        [data](uint32_t result) { LOG_ASSERT(==, data->logger(), result, 0x0); });
+    std::for_each(std::begin(query_results), std::end(query_results),
+                  [data](uint32_t result) {
+                    LOG_ASSERT(==, data->logger(), result, 0x0);
+                  });
   }
 
   {
@@ -379,8 +384,9 @@ int main_entry(const entry::EntryData* data) {
     const uint32_t total_num_queries = 8;
     const uint32_t get_result_num_queries = 4;
     vulkan::VkQueryPool query_pool = QueryWithoutDrawingAnything(
-        data, &app, {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
-                     VK_QUERY_TYPE_OCCLUSION, total_num_queries, 0});
+        data, &app,
+        {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
+         VK_QUERY_TYPE_OCCLUSION, total_num_queries, 0});
     std::array<uint64_t, get_result_num_queries> query_results{
         0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
         0xFFFFFFFFFFFFFFFF};
@@ -397,9 +403,10 @@ int main_entry(const entry::EntryData* data) {
                    ),
                VK_SUCCESS);
 
-    std::for_each(
-        query_results.begin(), query_results.end(),
-        [data](uint64_t result) { LOG_ASSERT(==, data->logger(), result, 0x0); });
+    std::for_each(query_results.begin(), query_results.end(),
+                  [data](uint64_t result) {
+                    LOG_ASSERT(==, data->logger(), result, 0x0);
+                  });
   }
 
   {
@@ -409,11 +416,11 @@ int main_entry(const entry::EntryData* data) {
     const uint32_t num_queries = 4;
     const uint32_t stride = 12;
     vulkan::VkQueryPool query_pool = QueryWithoutDrawingAnything(
-        data, &app, {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
-                     VK_QUERY_TYPE_OCCLUSION, num_queries, 0});
+        data, &app,
+        {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, nullptr, 0,
+         VK_QUERY_TYPE_OCCLUSION, num_queries, 0});
     containers::vector<uint32_t> query_results(
-        stride / sizeof(uint32_t) * num_queries, 0xFFFFFFFF,
-        data->allocator());
+        stride / sizeof(uint32_t) * num_queries, 0xFFFFFFFF, data->allocator());
     LOG_ASSERT(==, data->logger(),
                app.device()->vkGetQueryPoolResults(
                    app.device(),                             // device

--- a/gapid_tests/resource_acquisition_tests/vkGetRenderAreaGranularity_test/main.cpp
+++ b/gapid_tests/resource_acquisition_tests/vkGetRenderAreaGranularity_test/main.cpp
@@ -90,14 +90,15 @@ vulkan::VkRenderPass CreateRenderpass(const entry::EntryData* data,
           nullptr                           // pPreserveAttachments
       }},                                   // SubpassDescriptions
       {}                                    // SubpassDependencies
-      );
+  );
   return render_pass;
 }
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   auto render_pass = CreateRenderpass(data, &app);
   VkExtent2D granularity = {0};
   app.device()->vkGetRenderAreaGranularity(app.device(), render_pass,

--- a/gapid_tests/resource_binding_tests/vkUpdateDescriptorSets_test/main.cpp
+++ b/gapid_tests/resource_binding_tests/vkUpdateDescriptorSets_test/main.cpp
@@ -26,7 +26,8 @@ int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
   auto allocator = data->allocator();
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
 
   {  // 1. Zero writes and zero copies.
@@ -180,8 +181,7 @@ int main_entry(const entry::EntryData* data) {
     ::VkImageView raw_image_view;
     device->vkCreateImageView(device, &image_view_create_info, nullptr,
                               &raw_image_view);
-    vulkan::VkImageView image_view(raw_image_view, nullptr,
-                                         &device);
+    vulkan::VkImageView image_view(raw_image_view, nullptr, &device);
 
     const VkDescriptorImageInfo imginfo[3] = {
         // One image info for the first descriptor set

--- a/gapid_tests/resource_creation_tests/CreateDestroyBufferView_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyBufferView_test/main.cpp
@@ -23,7 +23,8 @@ int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
   vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data);
+                                        data,
+                                        vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = application.device();
 
   VkPhysicalDeviceProperties properties;

--- a/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/main.cpp
@@ -21,8 +21,8 @@
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                        data);
+  vulkan::VulkanApplication application(data->allocator(), data->logger(), data,
+                                        vulkan::VulkanApplicationOptions());
 
   {
     // 1. A query pool with queryCount of value 1, queryType of value

--- a/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/pipeline_statistic.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroyQueryPool_test/pipeline_statistic.cpp
@@ -31,8 +31,9 @@ int main_entry(const entry::EntryData* data) {
     // same physical device.
     VkPhysicalDeviceFeatures request_features = {0};
     request_features.pipelineStatisticsQuery = VK_TRUE;
-    vulkan::VulkanApplication application(data->allocator(), data->logger(),
-                                          data, {}, {}, request_features);
+    vulkan::VulkanApplication application(
+        data->allocator(), data->logger(), data,
+        vulkan::VulkanApplicationOptions(), {}, {}, request_features);
     if (application.device().is_valid()) {
       vulkan::VkDevice& device = application.device();
       VkQueryPoolCreateInfo query_pool_create_info = {

--- a/gapid_tests/resource_creation_tests/CreateDestroySampler_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroySampler_test/main.cpp
@@ -27,7 +27,8 @@ int main_entry(const entry::EntryData* data) {
 
   auto allocator = data->allocator();
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   {  // 1. Sampler using normalized coordinates
     vulkan::VkDevice& device = app.device();
     VkSamplerCreateInfo create_info{

--- a/gapid_tests/resource_creation_tests/CreateDestroySampler_test/unnormalized.cpp
+++ b/gapid_tests/resource_creation_tests/CreateDestroySampler_test/unnormalized.cpp
@@ -30,8 +30,9 @@ int main_entry(const entry::EntryData* data) {
   {  // Sampler using unnormalized coordinates
     VkPhysicalDeviceFeatures requested_features = {0};
     requested_features.samplerAnisotropy = VK_TRUE;
-    vulkan::VulkanApplication app(data->allocator(), data->logger(), data, {},
-                                  {}, requested_features);
+    vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                  vulkan::VulkanApplicationOptions(), {}, {},
+                                  requested_features);
     if (app.device().is_valid()) {
       vulkan::VkDevice& device = app.device();
       VkSamplerCreateInfo create_info{

--- a/gapid_tests/resource_creation_tests/FlushAndInvalidateRanges_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/FlushAndInvalidateRanges_test/main.cpp
@@ -24,7 +24,8 @@
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   vulkan::VkDevice& device = app.device();
   vulkan::VkCommandBuffer cmd_buf = app.GetCommandBuffer();
   ::VkCommandBuffer raw_cmd_buf = cmd_buf.get_command_buffer();
@@ -103,7 +104,7 @@ int main_entry(const entry::EntryData* data) {
                           map_size,                            // size
                           0,                                   // flags
                           reinterpret_cast<void**>(&buf_data)  // ppData
-                          );
+      );
       for (size_t i = 0; i < map_size; i++) {
         buf_data[i] = i & 0xFF;
       }
@@ -130,7 +131,10 @@ int main_entry(const entry::EntryData* data) {
 
       // Copy data from src buffer to dst buffer
       VkCommandBufferBeginInfo cmd_begin_info{
-          VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr, 0, nullptr,
+          VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+          nullptr,
+          0,
+          nullptr,
       };
       cmd_buf->vkBeginCommandBuffer(cmd_buf, &cmd_begin_info);
       VkMemoryBarrier flush_barrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER, nullptr,
@@ -174,7 +178,7 @@ int main_entry(const entry::EntryData* data) {
                           map_size,                            // size
                           0,                                   // flags
                           reinterpret_cast<void**>(&buf_data)  // ppData
-                          );
+      );
       VkMappedMemoryRange invalidate_range{
           VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,  // sType
           nullptr,                                // pNext
@@ -222,7 +226,7 @@ int main_entry(const entry::EntryData* data) {
                           map_size,                            // size
                           0,                                   // flags
                           reinterpret_cast<void**>(&buf_data)  // ppData
-                          );
+      );
       for (size_t i = 0; i < map_size; i++) {
         if (i < 512 - i) {
           buf_data[i] = i & 0xFF;
@@ -254,7 +258,10 @@ int main_entry(const entry::EntryData* data) {
 
       // Copy data from src buffer to dst buffer
       VkCommandBufferBeginInfo cmd_begin_info{
-          VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr, 0, nullptr,
+          VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+          nullptr,
+          0,
+          nullptr,
       };
       cmd_buf->vkBeginCommandBuffer(cmd_buf, &cmd_begin_info);
       VkMemoryBarrier flush_barrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER, nullptr,
@@ -296,7 +303,7 @@ int main_entry(const entry::EntryData* data) {
                           map_size,                            // size
                           0,                                   // flags
                           reinterpret_cast<void**>(&buf_data)  // ppData
-                          );
+      );
       VkMappedMemoryRange invalidate_range{
           VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,  // sType
           nullptr,                                // pNext

--- a/gapid_tests/resource_creation_tests/vkCreateGraphicsPipelines_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/vkCreateGraphicsPipelines_test/main.cpp
@@ -33,7 +33,8 @@ uint32_t vertex_shader[] =
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                        vulkan::VulkanApplicationOptions());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
 

--- a/gapid_tests/resource_creation_tests/vkCreatePipelineLayout_test/main.cpp
+++ b/gapid_tests/resource_creation_tests/vkCreatePipelineLayout_test/main.cpp
@@ -25,7 +25,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
 

--- a/gapid_tests/synchronization_tests/Event_test/main.cpp
+++ b/gapid_tests/synchronization_tests/Event_test/main.cpp
@@ -13,6 +13,11 @@
  * limitations under the License.
  */
 
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+
 #include "support/entry/entry.h"
 #include "support/log/log.h"
 #include "vulkan_helpers/known_device_infos.h"
@@ -21,11 +26,6 @@
 #include "vulkan_wrapper/instance_wrapper.h"
 #include "vulkan_wrapper/library_wrapper.h"
 #include "vulkan_wrapper/sub_objects.h"
-
-#include <condition_variable>
-#include <functional>
-#include <mutex>
-#include <thread>
 
 namespace {
 // Records a vkCmdWaitEvents command without any memory barrier in the command
@@ -109,7 +109,8 @@ struct CommonHandles {
 
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   // Basic test of vkSetEvent, vkResetEvent and vkGetEventStatus
   {
     // Use "TAG" in the trace to figure out where we are supposed to be

--- a/gapid_tests/synchronization_tests/Fence_test/main.cpp
+++ b/gapid_tests/synchronization_tests/Fence_test/main.cpp
@@ -25,7 +25,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                        vulkan::VulkanApplicationOptions());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
   vulkan::VkQueue& render_queue = app.render_queue();

--- a/gapid_tests/synchronization_tests/vkDeviceWaitIdle_test/main.cpp
+++ b/gapid_tests/synchronization_tests/vkDeviceWaitIdle_test/main.cpp
@@ -22,7 +22,8 @@
 int main_entry(const entry::EntryData* data) {
   data->logger()->LogInfo("Application Startup");
 
-  vulkan::VulkanApplication app(data->allocator(), data->logger(), data);
+  vulkan::VulkanApplication app(data->allocator(), data->logger(), data,
+                                vulkan::VulkanApplicationOptions());
   // So we don't have to type app.device every time.
   vulkan::VkDevice& device = app.device();
   vulkan::VkQueue& render_queue = app.render_queue();

--- a/vulkan_helpers/vulkan_application.cpp
+++ b/vulkan_helpers/vulkan_application.cpp
@@ -42,8 +42,9 @@ VkDescriptorPool DescriptorSet::CreateDescriptorPool(
     pool_sizes.push_back({static_cast<VkDescriptorType>(p.first), p.second});
   }
 
-  return vulkan::CreateDescriptorPool(
-      device, static_cast<uint32_t>(pool_sizes.size()), pool_sizes.data(), 1, pNext);
+  return vulkan::CreateDescriptorPool(device,
+                                      static_cast<uint32_t>(pool_sizes.size()),
+                                      pool_sizes.data(), 1, pNext);
 }
 
 DescriptorSet::DescriptorSet(
@@ -53,69 +54,6 @@ DescriptorSet::DescriptorSet(
       layout_(CreateDescriptorSetLayout(allocator, device, bindings)),
       set_(AllocateDescriptorSet(device, pool_.get_raw_object(),
                                  layout_.get_raw_object())) {}
-
-VulkanApplicationOptions FromLegacyVulkanApplicationOptions(
-    uint32_t host_buffer_size = 1024 * 1024,
-    uint32_t device_image_size = 1024 * 1024,
-    uint32_t device_buffer_size = 1024 * 1024,
-    uint32_t coherent_buffer_size = 1024 * 1024,
-    bool use_async_compute_queue = false, bool use_sparse_binding = false,
-    bool use_device_groups = false, uint32_t device_peer_memory_size = 0,
-    bool use_protected_memory = false, bool use_host_query_reset = false,
-    VkColorSpaceKHR swapchain_color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
-    bool use_shared_presentation = false,
-    bool use_mutable_swapchain_format = false,
-    const void* swapchain_extensions = nullptr, bool use_vulkan_1_1 = false,
-    bool use_10bit_hdr = false, void* device_next = nullptr,
-    uint32_t min_swapchain_image_count = 0) {
-  VulkanApplicationOptions options = {};
-  options.host_buffer_size = host_buffer_size;
-  options.device_image_size = device_image_size;
-  options.device_buffer_size = device_buffer_size;
-  options.coherent_buffer_size = coherent_buffer_size;
-  options.use_async_compute_queue = use_async_compute_queue;
-  options.use_sparse_binding = use_sparse_binding;
-  options.use_device_groups = use_device_groups;
-  options.device_peer_memory_size = device_peer_memory_size;
-  options.use_protected_memory = use_protected_memory;
-  options.use_host_query_reset = use_host_query_reset;
-  options.swapchain_color_space = swapchain_color_space;
-  options.use_shared_presentation = use_shared_presentation;
-  options.use_mutable_swapchain_format = use_mutable_swapchain_format;
-  options.swapchain_extensions = swapchain_extensions;
-  options.vulkan_api_version =
-      use_vulkan_1_1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0;
-  options.use_10bit_hdr = use_10bit_hdr;
-  options.device_next = device_next;
-  options.min_swapchain_image_count = min_swapchain_image_count;
-  return options;
-}
-
-VulkanApplication::VulkanApplication(
-    containers::Allocator* allocator, logging::Logger* log,
-    const entry::EntryData* entry_data,
-    const std::initializer_list<const char*> instance_extensions,
-    const std::initializer_list<const char*> device_extensions,
-    const VkPhysicalDeviceFeatures& features, uint32_t host_buffer_size,
-    uint32_t device_image_size, uint32_t device_buffer_size,
-    uint32_t coherent_buffer_size, bool use_async_compute_queue,
-    bool use_sparse_binding, bool use_device_group,
-    uint32_t device_peer_memory_size, bool use_protected_memory,
-    bool use_host_query_reset, VkColorSpaceKHR swapchain_color_space,
-    bool use_shared_presentation, bool use_mutable_swapchain_format,
-    const void* swapchain_extensions, bool use_vulkan_1_1, bool use_10bit_hdr,
-    void* device_next, uint32_t min_swapchain_image_count)
-    : VulkanApplication(
-          allocator, log, entry_data,
-          FromLegacyVulkanApplicationOptions(
-              host_buffer_size, device_image_size, device_buffer_size,
-              coherent_buffer_size, use_async_compute_queue, use_sparse_binding,
-              use_device_group, device_peer_memory_size, use_protected_memory,
-              use_host_query_reset, swapchain_color_space,
-              use_shared_presentation, use_mutable_swapchain_format,
-              swapchain_extensions, use_vulkan_1_1, use_10bit_hdr, device_next,
-              min_swapchain_image_count),
-          instance_extensions, device_extensions, features) {}
 
 VulkanApplication::VulkanApplication(
     containers::Allocator* allocator, logging::Logger* log,

--- a/vulkan_helpers/vulkan_application.h
+++ b/vulkan_helpers/vulkan_application.h
@@ -119,7 +119,7 @@ struct VulkanApplicationOptions {
     use_10bit_hdr = true;
     return *this;
   }
-  
+
   VulkanApplicationOptions& SetVulkanApiVersion(uint32_t vulkan_api_version) {
     this->vulkan_api_version = vulkan_api_version;
     return *this;
@@ -415,12 +415,14 @@ class DescriptorSet {
 
   static VkDescriptorPool CreateDescriptorPool(
       containers::Allocator* allocator, VkDevice* device,
-      std::initializer_list<VkDescriptorSetLayoutBinding> bindings, void* pNext = nullptr);
+      std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
+      void* pNext = nullptr);
 
   // Creates a descriptor set with one descriptor according to the given
   // |binding|.
   DescriptorSet(containers::Allocator* allocator, VkDevice* device,
-                std::initializer_list<VkDescriptorSetLayoutBinding> bindings, void* pNext = nullptr);
+                std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
+                void* pNext = nullptr);
 
   // Pools is designed to amortize the cost of descriptor set allocation.
   // But here we create a dedicated pool for each descriptor set. It suffers
@@ -580,30 +582,6 @@ class VulkanApplication {
 
   // On creation creates an instance, device, surface, swapchain, queues,
   // and command pool for the application.
-  // It also creates 3 memory arenas with the given sizes.
-  //  One for host-visible buffers.
-  //  One for device-only-accessible buffers.
-  //  One for device-only images.
-  VulkanApplication(
-      containers::Allocator* allocator, logging::Logger* log,
-      const entry::EntryData* entry_data,
-      const std::initializer_list<const char*> instance_extensions = {},
-      const std::initializer_list<const char*> device_extensions = {},
-      const VkPhysicalDeviceFeatures& features = {0},
-      uint32_t host_buffer_size = 1024 * 1024,
-      uint32_t device_image_size = 1024 * 1024,
-      uint32_t device_buffer_size = 1024 * 1024,
-      uint32_t coherent_buffer_size = 1024 * 1024,
-      bool use_async_compute_queue = false, bool use_sparse_binding = false,
-      bool use_device_groups = false, uint32_t device_peer_memory_size = 0,
-      bool use_protected_memory = false, bool use_host_query_reset = false,
-      VkColorSpaceKHR swapchain_color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
-      bool use_shared_presentation = false,
-      bool use_mutable_swapchain_format = false,
-      const void* swapchain_extensions = nullptr, bool use_vulkan_1_1 = false,
-      bool use_10bit_hdr = false, void* device_next = nullptr,
-      uint32_t min_swapchain_image_count = 0);
-
   VulkanApplication(
       containers::Allocator* allocator, logging::Logger* log,
       const entry::EntryData* entry_data,
@@ -870,7 +848,8 @@ class VulkanApplication {
   // Allocates a descriptor set with one descriptor according to the given
   // |binding|.
   DescriptorSet AllocateDescriptorSet(
-      std::initializer_list<VkDescriptorSetLayoutBinding> bindings, void* pNext = nullptr) {
+      std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
+      void* pNext = nullptr) {
     return DescriptorSet(allocator_, &device_, bindings, pNext);
   }
 


### PR DESCRIPTION
The old API was bloated and bad. We have switched to a new
API. This updates all remaining samples to the new API
and removes the old one completely.